### PR TITLE
Iss95 apostrophes

### DIFF
--- a/js/ssSearch.js
+++ b/js/ssSearch.js
@@ -1490,8 +1490,12 @@ if (this.discardedTerms.length > 0){
           for (let phr of phrases){
   //Get the term we decided to use to retrieve index data.
             let stem = self.terms[phr].stem;
+            
+  //Expand apostrophes into their variants
+           let rePhrStr = self.terms[phr].str.replace(/'/g, "['‘’‛]");
+  
   //Make the phrase into a regex for matching.
-            let rePhr = new RegExp('\\b' + self.terms[phr].str + '\\b', 'i');
+            let rePhr = new RegExp('\\b' + rePhrStr + '\\b', 'i');
   //If that term is in the index (it should be, even if it's empty, but still...)
             if (self.index[stem]){
   //Look at each of the document instances for that term...

--- a/js/ssSearch.js
+++ b/js/ssSearch.js
@@ -665,14 +665,17 @@ class StaticSearch{
       //Next, replace curly quotes/apostrophes with straight.
       strSearch = strSearch.replace(/[“”]/g, '"');
       strSearch = strSearch.replace(/[‘’‛]/g, "'");
+      
+      //Then remove any leading or trailing apostrophes
+      strSearch = strSearch.replace(/(^'|'$)/g,'');
 
       //Strip out all other punctuation that isn't between numbers. We do this
       //slightly differently depending on whether wildcard searching is enabled.
       if (this.allowWildcards){
-        strSearch = strSearch.replace(/(^|[^\d])[\.',!;:@#$%\^&]+([^\d]|$)/g, '$1$2');
+        strSearch = strSearch.replace(/(^|[^\d])[\.,!;:@#$%\^&]+([^\d]|$)/g, '$1$2');
       }
       else{
-        strSearch = strSearch.replace(/(^|[^\d])[\.',!;:@#$%\^&*?\[\]]+([^\d]|$)/g, '$1$2');
+        strSearch = strSearch.replace(/(^|[^\d])[\.,!;:@#$%\^&*?\[\]]+([^\d]|$)/g, '$1$2');
       }
 
       //If we're not supporting phrasal searches, get rid of double quotes.

--- a/test/apostrophes.html
+++ b/test/apostrophes.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html id="apostrophes" xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <title>Selection from Martin Porter's "The apostrophe character"</title>
+        
+        <meta name="Document type" class="staticSearch.desc" content="Article extracts"/>
+        <meta name="Date range" class="staticSearch.date" content="1689" />
+        <meta name="Worth reading" class="staticSearch.bool" content="true" />
+        <style>
+            body{
+                max-width: 45rem;
+                margin: 0 auto;
+            }
+            #text{
+                padding: 1rem;
+                margin-left: 1rem;
+                border: 1px dashed #141414;
+            }
+           
+        </style>
+    </head>
+    <body>
+        <div id="preamble">
+            <p>The following is taken from Martin Porter's discussion of apostrophes in English for the Porter2 Stemmer:
+                <a href="http://snowball.tartarus.org/texts/apostrophe.html">http://snowball.tartarus.org/texts/apostrophe.html</a>. The text is unchanged,
+                but it has been slightly re-encoded (<code>p</code>s instead of <code>br</code>s, for instance).
+            
+            </p>
+        </div>
+        <div id="text">
+            <blockquote>
+                <h2>The apostrophe character</h2>
+                
+                <p>Representing apostrophe is problematical for various reasons,</p>
+                <ol style="list-style-type: lower-alpha;">
+                    <li>There are two Unicode characters for apostrophe, U+0027 (also ASCII hex
+                        27), and U+2019. Compare <br/>
+                        <pre>        Hamlet's father's ghost (U+0027)
+        Hamlet’s father’s ghost (U+2019)
+</pre></li>
+                    <li>Although conceptually different from an apostrophe, a single closing
+                        quote is also represented by character U+2019.</li>
+                    <li>Character U+0027 is used for apostrophe, single closing quote and
+                        single opening quote (U+2018).</li>
+                    <li>A fourth character, U+201B, like U+2018 but with the tail ‘rising’
+                        instead of ‘descending’, is also sometimes used as apostrophe (in the
+                        house style of certain publishers, for surnames like <i>M’Coy</i> and so on.)
+                    </li>
+                </ol>
+                <p>In the English stemming algorithm, it is assumed that apostrophe is
+                    represented by U+0027. This makes it ASCII compatible. Clearly other codes
+                    for apostrophe can be mapped to this code prior to stemming.</p>
+                
+                <p>In English orthography, apostrophe has one of three functions.</p>
+                <ol>
+                    <li>It indicates a contraction in what is now accepted as a single word:
+                        <i>o’clock</i>, <i>O’Reilly</i>, <i>M’Coy</i>. Except in proper names such forms
+                        are rare: the apostrophe in <i>Hallowe’en</i> is disappearing, and in
+                        <i>’bus</i> has disappeared.</li>
+                    <li>It indicates a standard contraction with auxiliary or modal verbs:
+                        <i>you’re</i>, <i>isn’t</i>, <i>we’d</i>. There are about forty of these forms in
+                        contemporary English, and their use is increasing as they displace the full
+                        forms that were at one time used in formal documents. Although they can be
+                        reduced to word pairs, it is more convenient to treat them as single items
+                        (usually stopwords) in IR work. And then preserving the apostrophe is
+                        important, so that <i>he’ll</i>, <i>she’ll</i>, <i>we’ll</i> are not equated with
+                        <i>hell</i>, <i>shell</i>, <i>well</i> etc.</li>
+                    <li>It is used to form the ‘English genitive’, <i>John's book</i>, <i>the horses’
+                        hooves</i> etc. This is a development of (1), where historically the apostrophe
+                        stood for an elided <b><i>e</i></b>. (Similarly the printed form <b><i>’d</i></b> for <b><i>ed</i></b> was
+                        very common before the nineteenth century.) Although in decline (witness <i>pigs
+                            trotters</i>, <i>Girls School Trust</i>), its use continues in contemporary
+                        English, where it is fiercely promoted as correct grammar, despite (or it might
+                        be closer to the truth to say <i>because of</i>) its complete semantic redundancy.</li>
+                </ol>
+                <p>For these reasons, the English stemmer treats apostrophe as a letter, removing
+                    it from the beginning of a word, where it might have stood for an opening
+                    quote, from the end of the word, where it might have stood for a closing quote,
+                    or been an apostrophe following <b><i>s</i></b>. The form <b><i>’s</i></b> is also treated as an ending.</p>
+            </blockquote>
+            <cite>Martin Porter, "The apostrophe character," <a href="http://snowball.tartarus.org/texts/apostrophe.html">http://snowball.tartarus.org/texts/apostrophe.html</a></cite>
+            
+        </div>
+    </body>
+</html>

--- a/test/apostrophes.html
+++ b/test/apostrophes.html
@@ -23,10 +23,9 @@
     <body>
         <div id="preamble">
             <p>The following is a segment of Martin Porter's discussion of apostrophes in English for the Porter2 Stemmer:
-                <a href="http://snowball.tartarus.org/texts/apostrophe.html">http://snowball.tartarus.org/texts/apostrophe.html</a>. The text is unchanged,
-                but it has been slightly re-encoded (<code>p</code>s instead of <code>br</code>s, for instance).
-            
+                <a href="http://snowball.tartarus.org/texts/apostrophe.html">http://snowball.tartarus.org/texts/apostrophe.html</a>, included here as it provides good examples of apostrophes (for instance, <q>o'clock</q>, <q>O'Reilly</q>, etc.).
             </p>
+            <p> The text is unchanged, but it has been slightly re-encoded (<code>p</code>s instead of <code>br</code>s, for instance)</p>
         </div>
         <div id="text">
             <blockquote>

--- a/test/apostrophes.html
+++ b/test/apostrophes.html
@@ -22,7 +22,7 @@
     </head>
     <body>
         <div id="preamble">
-            <p>The following is taken from Martin Porter's discussion of apostrophes in English for the Porter2 Stemmer:
+            <p>The following is a segment of Martin Porter's discussion of apostrophes in English for the Porter2 Stemmer:
                 <a href="http://snowball.tartarus.org/texts/apostrophe.html">http://snowball.tartarus.org/texts/apostrophe.html</a>. The text is unchanged,
                 but it has been slightly re-encoded (<code>p</code>s instead of <code>br</code>s, for instance).
             
@@ -30,28 +30,7 @@
         </div>
         <div id="text">
             <blockquote>
-                <h2>The apostrophe character</h2>
-                
-                <p>Representing apostrophe is problematical for various reasons,</p>
-                <ol style="list-style-type: lower-alpha;">
-                    <li>There are two Unicode characters for apostrophe, U+0027 (also ASCII hex
-                        27), and U+2019. Compare <br/>
-                        <pre>        Hamlet's father's ghost (U+0027)
-        Hamlet’s father’s ghost (U+2019)
-</pre></li>
-                    <li>Although conceptually different from an apostrophe, a single closing
-                        quote is also represented by character U+2019.</li>
-                    <li>Character U+0027 is used for apostrophe, single closing quote and
-                        single opening quote (U+2018).</li>
-                    <li>A fourth character, U+201B, like U+2018 but with the tail ‘rising’
-                        instead of ‘descending’, is also sometimes used as apostrophe (in the
-                        house style of certain publishers, for surnames like <i>M’Coy</i> and so on.)
-                    </li>
-                </ol>
-                <p>In the English stemming algorithm, it is assumed that apostrophe is
-                    represented by U+0027. This makes it ASCII compatible. Clearly other codes
-                    for apostrophe can be mapped to this code prior to stemming.</p>
-                
+                <p>[...]</p>
                 <p>In English orthography, apostrophe has one of three functions.</p>
                 <ol>
                     <li>It indicates a contraction in what is now accepted as a single word:

--- a/test/index.html
+++ b/test/index.html
@@ -14,7 +14,7 @@
         <div>
             <h1>Test data set</h1>
             <p>Documents in the collection: <a href="badthings.html">badthings.html</a>, 
-                <a href="badthings.html">badthings.html</a>, 
+                <a href="apostrophes.html">apostrophes.html</a>, 
                 <a href="clues.html">clues.html</a>, 
                 <a href="poems/ditty.html">ditty.html</a>, 
                 <a href="poems/shizukesaya.html">shizukesaya.html</a>, 
@@ -37,14 +37,16 @@
                 <li>Good range of HTML elements providing scope for testing context stuff.</li>
                 <li>Foreign languages and non-latin stuff such as Japanese.</li>
                 <li>Hyphenated terms, single and double, such as one-way street and hard-to-process sequences.</li>
+                <li>Apostrophes in various positions, including leading, trailing, and word-internal.</li>
                 <li>Names, both in sentence-initial and sentence medial positions. Fred Bloggs and Mary Wollstonecraft Shelley are examples.</li>
                 <li>Numbers such as 25, 2,302, and 3.14159, or currency amounts such as £4,500 or ¥9,000,000.</li>
                 <li>Items that should not be indexed (such as line numbers attached to poetic lines).</li>
                 <li>Constrained contexts which should delimit keyword-in-context ranges, such as table cells.</li>
                 <li>Inline elements whose boundaries should be ignored when indexing.</li>
+                <li>Fragment ids for specifying anchor links from KWICs</li>
             </ul>
             <p>There are three poems, two Victorian and one Japanese (about cicadas). There are also two documents
-            with tables, one of which dals with liquor consumption in British Columbia, while the other has numbers
+            with tables, one of which deals with liquor consumption in British Columbia, while the other has numbers
             such as 1783 and percentages such as 73.58%. One of the poems includes the phrase <q>summer day—our day</q>, 
             and if we follow that to the next line we get <q>our day Was clouded</q>, which should be indexed/found 
                 in this document, but not in the source poem, where lines are boundary contexts.</p>

--- a/test/index.html
+++ b/test/index.html
@@ -49,7 +49,8 @@
             with tables, one of which deals with liquor consumption in British Columbia, while the other has numbers
             such as 1783 and percentages such as 73.58%. One of the poems includes the phrase <q>summer day—our day</q>, 
             and if we follow that to the next line we get <q>our day Was clouded</q>, which should be indexed/found 
-                in this document, but not in the source poem, where lines are boundary contexts.</p>
+                in this document, but not in the source poem, where lines are boundary contexts. The apostrophes document
+                is an excerpt from Martin Porter’s site (note the curly apostrophe in his name).</p>
             
             <p>The word <em>artichoke</em> appears here and in one other document, but it is included in the 
             test stopwords list so it should not be indexed or retrieved.</p>

--- a/test/search.html
+++ b/test/search.html
@@ -149,26 +149,26 @@
       <div id="staticSearch"><script src="ssTest/ssStemmer.js"></script><script src="ssTest/ssSearch.js"></script><script>
                 var Sch;
                 window.addEventListener('load', function(){Sch = new StaticSearch();});
-            </script><form accept-charset="UTF-8" id="ssForm" data-allowphrasal="yes" data-allowwildcards="yes" data-scrolltotextfragment="yes" data-maxkwicstoshow="3" onsubmit="return false;" data-versionstring="_da650f3" data-ssfolder="ssTest" data-kwictruncatestring="..."><span class="ssQueryAndButton"><input type="text" id="ssQuery"/><button id="ssDoSearch">Search</button></span><span class="clearButton"><button id="ssClear">Clear</button></span><div class="ssDescFilters">
+            </script><form accept-charset="UTF-8" id="ssForm" data-allowphrasal="yes" data-allowwildcards="yes" data-scrolltotextfragment="yes" data-maxkwicstoshow="3" onsubmit="return false;" data-versionstring="_ddc6234" data-ssfolder="ssTest" data-kwictruncatestring="..."><span class="ssQueryAndButton"><input type="text" id="ssQuery"/><button id="ssDoSearch">Search</button></span><span class="clearButton"><button id="ssClear">Clear</button></span><div class="ssDescFilters">
                <fieldset class="ssFieldset" title="Document type" id="ssDesc1">
                   <legend>Document type</legend>
                   <ul class="ssDescCheckboxList">
-                     <li><input type="checkbox" title="Document type" value="Article extracts" id="ssDesc1_2" class="staticSearch.desc"/><label for="ssDesc1_2">Article extracts</label></li>
-                     <li><input type="checkbox" title="Document type" value="Documents with tables" id="ssDesc1_4" class="staticSearch.desc"/><label for="ssDesc1_4">Documents with tables</label></li>
+                     <li><input type="checkbox" title="Document type" value="Article extracts" id="ssDesc1_4" class="staticSearch.desc"/><label for="ssDesc1_4">Article extracts</label></li>
+                     <li><input type="checkbox" title="Document type" value="Documents with tables" id="ssDesc1_1" class="staticSearch.desc"/><label for="ssDesc1_1">Documents with tables</label></li>
                      <li><input type="checkbox" title="Document type" value="Poems" id="ssDesc1_3" class="staticSearch.desc"/><label for="ssDesc1_3">Poems</label></li>
-                     <li><input type="checkbox" title="Document type" value="Site info files" id="ssDesc1_1" class="staticSearch.desc"/><label for="ssDesc1_1">Site info files</label></li>
+                     <li><input type="checkbox" title="Document type" value="Site info files" id="ssDesc1_2" class="staticSearch.desc"/><label for="ssDesc1_2">Site info files</label></li>
                   </ul>
                </fieldset>
                <fieldset class="ssFieldset" title="Random numeric value" id="ssDesc2">
                   <legend>Random numeric value</legend>
                   <ul class="ssDescCheckboxList">
-                     <li><input type="checkbox" title="Random numeric value" value="1" id="ssDesc2_1" class="staticSearch.desc"/><label for="ssDesc2_1">1</label></li>
-                     <li><input type="checkbox" title="Random numeric value" value="2" id="ssDesc2_2" class="staticSearch.desc"/><label for="ssDesc2_2">2</label></li>
-                     <li><input type="checkbox" title="Random numeric value" value="3" id="ssDesc2_8" class="staticSearch.desc"/><label for="ssDesc2_8">3</label></li>
-                     <li><input type="checkbox" title="Random numeric value" value="4" id="ssDesc2_5" class="staticSearch.desc"/><label for="ssDesc2_5">4</label></li>
-                     <li><input type="checkbox" title="Random numeric value" value="11" id="ssDesc2_3" class="staticSearch.desc"/><label for="ssDesc2_3">11</label></li>
-                     <li><input type="checkbox" title="Random numeric value" value="21" id="ssDesc2_7" class="staticSearch.desc"/><label for="ssDesc2_7">21</label></li>
-                     <li><input type="checkbox" title="Random numeric value" value="31" id="ssDesc2_4" class="staticSearch.desc"/><label for="ssDesc2_4">31</label></li>
+                     <li><input type="checkbox" title="Random numeric value" value="1" id="ssDesc2_3" class="staticSearch.desc"/><label for="ssDesc2_3">1</label></li>
+                     <li><input type="checkbox" title="Random numeric value" value="2" id="ssDesc2_5" class="staticSearch.desc"/><label for="ssDesc2_5">2</label></li>
+                     <li><input type="checkbox" title="Random numeric value" value="3" id="ssDesc2_2" class="staticSearch.desc"/><label for="ssDesc2_2">3</label></li>
+                     <li><input type="checkbox" title="Random numeric value" value="4" id="ssDesc2_4" class="staticSearch.desc"/><label for="ssDesc2_4">4</label></li>
+                     <li><input type="checkbox" title="Random numeric value" value="11" id="ssDesc2_7" class="staticSearch.desc"/><label for="ssDesc2_7">11</label></li>
+                     <li><input type="checkbox" title="Random numeric value" value="21" id="ssDesc2_1" class="staticSearch.desc"/><label for="ssDesc2_1">21</label></li>
+                     <li><input type="checkbox" title="Random numeric value" value="31" id="ssDesc2_8" class="staticSearch.desc"/><label for="ssDesc2_8">31</label></li>
                      <li><input type="checkbox" title="Random numeric value" value="41" id="ssDesc2_6" class="staticSearch.desc"/><label for="ssDesc2_6">41</label></li>
                   </ul>
                </fieldset>
@@ -261,7 +261,36 @@
                        check: function(num){console.log('Search hook ' + num);
                                             console.log('Testing results for the word "twilight".');
                                             checkResults({docsFound: 2, contextsFound: 3, scoreTotal: 3});}});
-
+                                            
+           //One word search word-internal apostrophe search
+           tests.push({
+                setup: function(){Sch.queryBox.value = "o'clock";},
+                check: function(num){
+                       console.log("Search hook " + num);
+                       console.log(`Testing results for word with word-internal apostrophe "o'clock".`);
+                       checkResults({
+                        docsFound: 1,
+                        contextsFound: 2,
+                        scoreTotal: 2
+                       })
+                }
+           
+           });
+           
+           //One word possessive apostrophe search
+           tests.push({
+                setup: function(){Sch.queryBox.value = "Porter’s"},
+                check: function(num){
+                        console.log ("Search hook " + num);
+                        console.log('Testing results for possessive curly apostrophe "Porter’s".');
+                        checkResults({
+                            docsFound: 2,
+                            contextsFound: 4,
+                            scoreTotal: 4
+                        })
+                     }
+           });
+    
            //Another simple one-word search but using a desc filter.
            tests.push({setup: function(){Sch.queryBox.value = 'twilight'; document.querySelector('input[value="Site info files"]').checked = 'checked';},
                        check: function(num){console.log('Search hook ' + num);

--- a/xsl/tokenize.xsl
+++ b/xsl/tokenize.xsl
@@ -83,15 +83,22 @@
     <xsl:variable name="curlyDoubleAposClose">”</xsl:variable>
     <xsl:variable name="straightDoubleApos">"</xsl:variable>
     
-    <xsl:variable name="allSingleApos" select="($straightSingleApos, $curlyAposOpen, $curlyAposClose)" as="xs:string+"/>
-    <xsl:variable name="allDoubleApos" select="($curlyDoubleAposClose, $curlyDoubleAposOpen, $straightDoubleApos)" as="xs:string+"/>
-    
-    <xd:doc>
-        <xd:desc>All apostrophes as a sequence (not concatenated or joined)</xd:desc>
-    </xd:doc>
-    <xsl:variable name="allApos" 
-        select="($allSingleApos, $allDoubleApos)"
+    <xsl:variable name="allSingleApos" 
+        select="($straightSingleApos, $curlyAposOpen, $curlyAposClose)"
         as="xs:string+"/>
+    
+    <xsl:variable name="allSingleAposCharClassRex" 
+        select="'[' || string-join($allSingleApos) || ']'" 
+        as="xs:string"/>
+    
+    <xsl:variable name="allDoubleApos" 
+        select="($curlyDoubleAposClose, $curlyDoubleAposOpen, $straightDoubleApos)" 
+        as="xs:string+"/>
+    
+    <xsl:variable name="allDoubleAposCharClassRex"
+        select="'[' || string-join($allDoubleApos) || ']'"
+        as="xs:string"/>
+    
     
      <xd:desc>
          <xd:doc>Regex to match words that are numeric with a decimal</xd:doc>
@@ -779,11 +786,15 @@
     </xd:doc>
     <xsl:function name="hcmc:cleanWordForStemming" as="xs:string">
         <xsl:param name="word" as="xs:string"/>
-        <!--First, replace any quotation marks in the middle of the word if there happen
-            to be any; then trim off any following periods -->
-        <xsl:value-of select="replace($word, '[' || string-join($allDoubleApos,'') || ']', '')
-            => replace('\.$','')
-            => translate('ſ','s')"/>
+        
+        <xsl:value-of select="
+            replace($word, $allDoubleAposCharClassRex, '') (: Remove all quotation marks :)
+            => replace($allSingleAposCharClassRex, $straightSingleApos) (: Normalize all apostrophes to straight :)
+            => replace('\.$','') (: Remove trailing period :)
+            => replace('^' || $straightSingleApos, '') (: Remove leading apostrope :)
+            => replace($straightSingleApos || '$', '') (: Remove trailing apostrophe :)
+            => translate('ſ','s') (: Normalize long-s to regular s :)
+            "/>
     </xsl:function>
     
     <xd:doc>

--- a/xsl/tokenize.xsl
+++ b/xsl/tokenize.xsl
@@ -100,15 +100,18 @@
         as="xs:string"/>
     
     
+    <xsl:variable name="allApos" select="($allSingleApos, $allDoubleApos)" as="xs:string+"/>
+    
+    
      <xd:desc>
          <xd:doc>Regex to match words that are numeric with a decimal</xd:doc>
      </xd:desc>
-    <xsl:variable name="numericWithDecimal">[<xsl:value-of select="string-join($allDoubleApos,'')"/>\d]+([\.,]?\d+)</xsl:variable>
+    <xsl:variable name="numericWithDecimal">[<xsl:value-of select="string-join($allApos,'')"/>\d]+([\.,]?\d+)</xsl:variable>
     
     <xd:desc>
         <xd:doc>Regex to match alphanumeric words</xd:doc>
     </xd:desc>
-    <xsl:variable name="alphanumeric">[\p{L}<xsl:value-of select="string-join($allDoubleApos,'')"/>]+</xsl:variable>
+    <xsl:variable name="alphanumeric">[\p{L}<xsl:value-of select="string-join($allApos,'')"/>]+</xsl:variable>
     
     <xd:desc>
         <xd:doc>Regex to match hyphenated words</xd:doc>
@@ -397,15 +400,6 @@
             will never contain information that should be indexed.</xd:desc>
     </xd:doc>
     <xsl:template match="script" mode="clean"/>
-    
-  
-<!--    <xd:doc>
-        <xd:desc>Template that normalizes the variety of apostrophe types into straight double apostrophes;
-            we do this here so that we don't have to account for it in the tokenization step.</xd:desc>
-    </xd:doc>
-    <xsl:template match="text()[matches(.,string-join(($curlyAposOpen,$curlyAposClose,$curlyDoubleAposClose, $curlyDoubleAposOpen),'|'))]" mode="clean">
-        <xsl:value-of select="replace(.,string-join(($curlyAposOpen,$curlyAposClose),'|'), $straightSingleApos) => replace(string-join(($curlyDoubleAposOpen,$curlyDoubleAposClose),'|'),$straightDoubleApos)"/>
-    </xsl:template>-->
     
     
     <xd:doc>


### PR DESCRIPTION
Handling for word internal apostrophes: don’t remove them from inside of words, but normalize them to straight when they go through the stemming process. Fixes #95. 

There are some commits here to deal with exact phrase matching, but the solution is only partial since we need to resolve those issues more broadly in #98 