### PR TITLE
Reworking phrasals and removal of uppercase index

### DIFF
--- a/js/ssSearch.js
+++ b/js/ssSearch.js
@@ -327,6 +327,10 @@ class StaticSearch{
 
       //Characters to be discarded in all but phrasal
       this.charsToDiscardPattern = /[\.,!;:@#$%\^&]/g;
+      if (!this.allowWildcards){
+          this.charsToDiscardPattern = /[\.,!;:@#$%\^&*?\[\]]/g;
+         
+      };
 
       //Captions
       this.captions = ss.captions; //Default; override this if you wish by setting the property after instantiation.
@@ -736,9 +740,14 @@ class StaticSearch{
       // spaces
       this.queryBox.value = this.terms.map(term => {
         let str = term.str;
-        //If it's a phrase, add quotation marks around it
+        if (term.type === MUST_CONTAIN){
+            return '+' + str;
+        }
+        if (term.type === MUST_NOT_CONTAIN){
+            return '-' + str;
+        }
         if (term.type === PHRASE){
-            str = '"' + str + '"';
+            return '"' + str + '"';
         }
         return str;
       }).join(" ");

--- a/js/ssSearch.js
+++ b/js/ssSearch.js
@@ -1508,7 +1508,7 @@ if (this.discardedTerms.length > 0){
           for (let phr of phrases){
   //Get the term we decided to use to retrieve index data.
             let stem = self.terms[phr].stem;
-  //Escape the phrase to have proper punctuation matching          
+  //Escape the phrase to have proper punctuation matching
             let escapedPhrase = self.terms[phr].str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
   //Expand the apostrophes into a character class          
             let expandedPhrase = escapedPhrase.replace(/'/g, "['‘’‛]");

--- a/js/ssSearch.js
+++ b/js/ssSearch.js
@@ -780,8 +780,6 @@ class StaticSearch{
     if (!isPhrasal && !this.termPattern.test(strInput)){
       this.normalizedQuery.push(strInput);
       this.discardedTerms.push(strInput);
-      // If this is a too broad wildcard, then add it back
-      // to the query string
       return false;
     }
 

--- a/js/ssSearch.js
+++ b/js/ssSearch.js
@@ -798,7 +798,7 @@ class StaticSearch{
     this.normalizedQuery.push('"' + strInput + '"');
 
     //We need to find the first component which is not a stopword.
-      let subterms = strInput.toLowerCase().split(/\s+/).map(term => term.replaceAll(this.charsToDiscardRex,''));
+      let subterms = strInput.toLowerCase().split(/\s+/).map(term => term.replaceAll(this.charsToDiscardPattern,''));
       let i;
       for (i = 0; i <= subterms.length; i++){
         if (this.stopwords.indexOf(subterms[i]) < 0){

--- a/js/ssSearch.js
+++ b/js/ssSearch.js
@@ -324,7 +324,7 @@ class StaticSearch{
       this.termPattern = new RegExp('^([\\*\\?\\[\\]]*[^\\*\\?\\[\\]]){' + this.charsRequired + ',}[\\*\\?\\[\\]]*$');
 
       //Characters to be discarded in all but phrasal
-      this.charsToDiscardPattern = /[\.,!;:@#$%\^&]/g;
+      this.charsToDiscardPattern = /[\.,!;:@#$%”“\^&]/g;
       if (!this.allowWildcards){
           this.charsToDiscardPattern = /[\.,!;:@#$%\^&*?\[\]]/g;
          
@@ -675,8 +675,7 @@ class StaticSearch{
       strSearch = strSearch.replace(/((^\s+)|\s+$)/g, '');
       strSearch = strSearch.replace(/\s+/g, ' ');
 
-      //Next, replace curly quotes/apostrophes with straight.
-      strSearch = strSearch.replace(/[“”]/g, '"');
+      //Next, replace curly apostrophes with straight.
       strSearch = strSearch.replace(/[‘’‛]/g, "'");
       
       //Then remove any leading or trailing apostrophes
@@ -1501,6 +1500,8 @@ if (this.discardedTerms.length > 0){
             let escapedPhrase = self.terms[phr].str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
   //Expand the apostrophes into a character class          
             let expandedPhrase = escapedPhrase.replace(/'/g, "['‘’‛]");
+  //Expand the quotation marks into a character class
+             expandedPhrase = expandedPhrase.replace(/[“”]/g, '[“”"]');
   //Make the phrase into a regex for matching.
             let rePhr = new RegExp('\\b' + expandedPhrase + '\\b');
   //If that term is in the index (it should be, even if it's empty, but still...)

--- a/js/ssSearch.js
+++ b/js/ssSearch.js
@@ -1760,7 +1760,7 @@ if (this.discardedTerms.length > 0){
     try{
       //Make the phrase into a regex for matching.
       let re = new RegExp(strRe);
-      return re
+      return re;
     }
     catch(e){
       console.log('Invalid regex from phrase created: ' + strRe);

--- a/test/search.html
+++ b/test/search.html
@@ -152,26 +152,26 @@
       <div id="staticSearch"><script src="ssTest/ssStemmer.js"></script><script src="ssTest/ssSearch.js"></script><script>
                 var Sch;
                 window.addEventListener('load', function(){Sch = new StaticSearch();});
-            </script><form accept-charset="UTF-8" id="ssForm" data-allowphrasal="yes" data-allowwildcards="yes" data-scrolltotextfragment="yes" data-maxkwicstoshow="3" onsubmit="return false;" data-versionstring="_2a84baa" data-ssfolder="ssTest" data-kwictruncatestring="..."><span class="ssQueryAndButton"><input type="text" id="ssQuery"/><button id="ssDoSearch">Search</button></span><span class="clearButton"><button id="ssClear">Clear</button></span><div class="ssDescFilters">
+            </script><form accept-charset="UTF-8" id="ssForm" data-allowphrasal="yes" data-allowwildcards="yes" data-scrolltotextfragment="yes" data-maxkwicstoshow="3" onsubmit="return false;" data-versionstring="_9517dc9" data-ssfolder="ssTest" data-kwictruncatestring="..."><span class="ssQueryAndButton"><input type="text" id="ssQuery"/><button id="ssDoSearch">Search</button></span><span class="clearButton"><button id="ssClear">Clear</button></span><div class="ssDescFilters">
                <fieldset class="ssFieldset" title="Document type" id="ssDesc1">
                   <legend>Document type</legend>
                   <ul class="ssDescCheckboxList">
-                     <li><input type="checkbox" title="Document type" value="Article extracts" id="ssDesc1_2" class="staticSearch.desc"/><label for="ssDesc1_2">Article extracts</label></li>
-                     <li><input type="checkbox" title="Document type" value="Documents with tables" id="ssDesc1_4" class="staticSearch.desc"/><label for="ssDesc1_4">Documents with tables</label></li>
+                     <li><input type="checkbox" title="Document type" value="Article extracts" id="ssDesc1_4" class="staticSearch.desc"/><label for="ssDesc1_4">Article extracts</label></li>
+                     <li><input type="checkbox" title="Document type" value="Documents with tables" id="ssDesc1_1" class="staticSearch.desc"/><label for="ssDesc1_1">Documents with tables</label></li>
                      <li><input type="checkbox" title="Document type" value="Poems" id="ssDesc1_3" class="staticSearch.desc"/><label for="ssDesc1_3">Poems</label></li>
-                     <li><input type="checkbox" title="Document type" value="Site info files" id="ssDesc1_1" class="staticSearch.desc"/><label for="ssDesc1_1">Site info files</label></li>
+                     <li><input type="checkbox" title="Document type" value="Site info files" id="ssDesc1_2" class="staticSearch.desc"/><label for="ssDesc1_2">Site info files</label></li>
                   </ul>
                </fieldset>
                <fieldset class="ssFieldset" title="Random numeric value" id="ssDesc2">
                   <legend>Random numeric value</legend>
                   <ul class="ssDescCheckboxList">
-                     <li><input type="checkbox" title="Random numeric value" value="1" id="ssDesc2_1" class="staticSearch.desc"/><label for="ssDesc2_1">1</label></li>
-                     <li><input type="checkbox" title="Random numeric value" value="2" id="ssDesc2_2" class="staticSearch.desc"/><label for="ssDesc2_2">2</label></li>
-                     <li><input type="checkbox" title="Random numeric value" value="3" id="ssDesc2_8" class="staticSearch.desc"/><label for="ssDesc2_8">3</label></li>
-                     <li><input type="checkbox" title="Random numeric value" value="4" id="ssDesc2_5" class="staticSearch.desc"/><label for="ssDesc2_5">4</label></li>
-                     <li><input type="checkbox" title="Random numeric value" value="11" id="ssDesc2_3" class="staticSearch.desc"/><label for="ssDesc2_3">11</label></li>
-                     <li><input type="checkbox" title="Random numeric value" value="21" id="ssDesc2_7" class="staticSearch.desc"/><label for="ssDesc2_7">21</label></li>
-                     <li><input type="checkbox" title="Random numeric value" value="31" id="ssDesc2_4" class="staticSearch.desc"/><label for="ssDesc2_4">31</label></li>
+                     <li><input type="checkbox" title="Random numeric value" value="1" id="ssDesc2_3" class="staticSearch.desc"/><label for="ssDesc2_3">1</label></li>
+                     <li><input type="checkbox" title="Random numeric value" value="2" id="ssDesc2_5" class="staticSearch.desc"/><label for="ssDesc2_5">2</label></li>
+                     <li><input type="checkbox" title="Random numeric value" value="3" id="ssDesc2_2" class="staticSearch.desc"/><label for="ssDesc2_2">3</label></li>
+                     <li><input type="checkbox" title="Random numeric value" value="4" id="ssDesc2_4" class="staticSearch.desc"/><label for="ssDesc2_4">4</label></li>
+                     <li><input type="checkbox" title="Random numeric value" value="11" id="ssDesc2_7" class="staticSearch.desc"/><label for="ssDesc2_7">11</label></li>
+                     <li><input type="checkbox" title="Random numeric value" value="21" id="ssDesc2_1" class="staticSearch.desc"/><label for="ssDesc2_1">21</label></li>
+                     <li><input type="checkbox" title="Random numeric value" value="31" id="ssDesc2_8" class="staticSearch.desc"/><label for="ssDesc2_8">31</label></li>
                      <li><input type="checkbox" title="Random numeric value" value="41" id="ssDesc2_6" class="staticSearch.desc"/><label for="ssDesc2_6">41</label></li>
                   </ul>
                </fieldset>
@@ -331,7 +331,55 @@
                                          console.log('Testing results for the phrase "our day Was clouded".');
                                          checkResults({docsFound: 1, contextsFound: 1, scoreTotal: 1});}});
 
-           //Phrasal search with boundary contexts.
+          //Phrasal search with embedded straight apostrophe
+          tests.push({
+             setup: function(){
+                Sch.queryBox.value = '"confounds the solver\'s attempt"';
+             },
+             check: function(num) {
+                console.log('Search hook ' + num);
+                console.log('Testing results for the phrase "confounds the solver\'s attempt".');
+                checkResults({
+                   docsFound: 1,
+                   contextsFound: 1,
+                   scoreTotal: 1
+                })
+             }
+          });
+
+          //Phrasal search that ends with punctuation
+          tests.push({
+             setup: function(){
+                Sch.queryBox.value = '"document,"';
+             },
+             check: function(num){
+                console.log('Search hook ' + num);
+                console.log('Testing results for the phrase "document,".');
+                checkResults({
+                   docsFound: 1,
+                   contextsFound: 2,
+                   scoreTotal: 2,
+                })
+             }
+          });
+
+          //Phrasal search that starts with a space
+          tests.push({
+             setup: function(){
+                Sch.queryBox.value = '" process"'
+             },
+             check: function(num){
+                console.log('Search hook ' + num);
+                console.log('Testing results for the phrase " process".');
+                checkResults({
+                   docsFound: 1,
+                   contextsFound: 1,
+                   scoreTotal: 1,
+                })
+             }
+          });
+
+           //Phrasal search with boundary contexts and date filter.
            tests.push({setup: function(){Sch.queryBox.value = '"our day Was clouded"'; document.querySelector('input[title="Date range"][id$="_to"]').value = '2000';},
                                          check: function(num){console.log('Search hook ' + num);
                                          console.log('Testing results for the phrase "our day Was clouded" with max date 2000.');
@@ -392,7 +440,6 @@
              Sch.showSearchReport = true;
              
              reportResults('Running automated tests.', true);
-
            }
 
            function reportResults(msg, succeed){
@@ -421,6 +468,7 @@
              msg += '; found ' + results.contextsFound + '. ';
              msg += 'Total of all scores: expected ' + obj.scoreTotal;
              msg += '; found ' + results.scoreTotal + '. ';
+             msg += ' (' + Sch.queryBox.value + ')';
              let succeed = ((obj.docsFound === results.docsFound)
                           &&(obj.contextsFound === results.contextsFound)
                           &&(obj.scoreTotal === results.scoreTotal));

--- a/xsl/functions.xsl
+++ b/xsl/functions.xsl
@@ -62,5 +62,47 @@
     <xsl:value-of select="string-join(($targetPathBits ! (if (position() lt count($rootPathBits) and $rootPathBits[position()] = .) then () else .)), '/')"/>
   </xsl:function>
   
+  
+  
+  <xd:doc>
+    <xd:desc><xd:ref name="hcmc:isForeign">hcmc:isForeign</xd:ref> determiners
+      whether or not an element is foreign (i.e. its declared language differs from the root language).</xd:desc>
+    <xd:param name="node">The node to check.</xd:param>
+    <xd:return>A boolean for whether or not the word is foreign.</xd:return>
+  </xd:doc>
+  <xsl:function name="hcmc:isForeign" as="xs:boolean">
+    <xsl:param name="node" as="node()"/>
+    
+    <!--Get the root HTML element-->
+    <xsl:variable name="root" select="$node/ancestor::html" as="element(html)"/>
+    
+    <!--Has a root language been declared?-->
+    <xsl:variable name="rootLangDeclared" select="boolean($root[@lang or @xml:lang])" as="xs:boolean"/>
+    
+    <!--Return the node's first ancestor with a declared language, if available-->
+    <xsl:variable name="langAncestor" select="$node/ancestor::*[not(self::html)][@*:lang][1]" as="element()?"/>
+    
+    <xsl:choose>
+      <!--If there is a declared language at the top and theres a lang ancestor
+                    then return the negation of whether or not they are equal
+                i.e. if they are equal, then return false (since it is NOT foreign)
+                -->
+      <xsl:when test="$rootLangDeclared and $langAncestor">
+        <xsl:value-of select="not(boolean($root/@*:lang = $langAncestor/@*:lang))"/>
+      </xsl:when>
+      
+      <!--If there is a lang ancestor but no root lang declared,
+                    then we must assume that it is foreign-->
+      <xsl:when test="$langAncestor and not($rootLangDeclared)">
+        <xsl:value-of select="true()"/>
+      </xsl:when>
+      
+      <!--Otherwise, just make it false-->
+      <xsl:otherwise>
+        <xsl:value-of select="false()"/>
+      </xsl:otherwise>
+    </xsl:choose>            
+  </xsl:function>
+  
 
 </xsl:stylesheet>

--- a/xsl/json.xsl
+++ b/xsl/json.xsl
@@ -116,14 +116,9 @@
             </xsl:variable>
             
               
-                <!--Now create the result document. Note that the JSONs are output into two directories (upper and lower)
-                as operating systems other than Linux tend to be case-insensitive, meaning that the last of
-                    August.json
-                    august.json
-
-                would silently overwrite the first. -->
+                <!--Now create the result document. -->
             
-            <xsl:result-document href="{$outDir}/{if (matches($stem,'^[A-Z]')) then 'upper' else 'lower'}/{$stem}{$versionString}.json" method="text">
+            <xsl:result-document href="{$outDir}/stems/{$stem}{$versionString}.json" method="text">
                 <xsl:value-of select="xml-to-json($map, map{'indent': $indentJSON})"/>
             </xsl:result-document>
         </xsl:for-each-group>


### PR DESCRIPTION
This pull request does a few things:

* It removes the upper-case index (#85), which was extraneous; its removal should mean faster indexing and faster searches
* It makes phrasal sensitives far more sensitive: we now handle punctuation (#98) and all phrases are case sensitive (#104)
* It also moves the isForeign and isInDictionary checks out of the tokenization and into the report pages; both of which are no longer necessary in the tokenization stage itself and are purely for diagnostic reasons.
