### PR TITLE
Better checking and processing of docTitle, docSortKey, and docImage

### DIFF
--- a/configTest.xml
+++ b/configTest.xml
@@ -35,4 +35,9 @@
         <context match="div[@class='l']" label="poetic lines"/>
         <context match="span[@class='note']" label="notes"/>
     </contexts>
+    
+    <excludes>
+        <exclude match="meta[contains-token(@class,'excludedMeta')]" type="filter"/>
+    </excludes>
+    
 </config>

--- a/test/apostrophes.html
+++ b/test/apostrophes.html
@@ -8,6 +8,7 @@
         <meta name="Date range" class="staticSearch.date" content="1689" />
         <meta name="Worth reading" class="staticSearch.bool" content="true" />
         <meta name="docSortKey" class="staticSearch.docSortKey" content="ddd"/>
+        <meta name="docTitle" class="staticSearch.docTitle myMeta" content="Porter, 'Apostrophe'"/>
         <style>
             body{
                 max-width: 45rem;

--- a/test/badthings.html
+++ b/test/badthings.html
@@ -13,7 +13,14 @@
         <!--This has multiple docImages, but one is excluded-->
         <meta name="docImage" class="staticSearch.docImage excludedMeta" content="images/booze.png"/>
         <meta name="docImage" class="staticSearch.docImage" content="images/lookout.svg"/>
-    
+        
+        <!--docTitle meta with no @class, which should raise a warning -->
+        <meta name="docTitle" content="Bad Document Title"/>
+        
+        <!--Multiple docSortKeys-->
+        <meta name="docSortKey" class="staticSearch.docSortKey" content="aaa"/>
+        <meta name="docSortKey" class="staticSearch.docSortKey" content="zzz"/>
+        
         <!-- This exists to test the situation where there are documents for
              one side of the boolean but not for others. -->
         <meta name="Is a document" class="staticSearch.bool" content="true" />

--- a/test/badthings.html
+++ b/test/badthings.html
@@ -10,7 +10,10 @@
         <meta name="Worth reading" class="staticSearch.bool" content="false" />
         <meta name="Random numeric value" class="staticSearch.desc" content="1" />
         <meta name="Number of animal names" class="staticSearch.num" content="6"/>
-         <meta class="staticSearch.docImage" name="docImage" content="images/lookout.svg"/>
+        <!--This has multiple docImages, but one is excluded-->
+        <meta name="docImage" class="staticSearch.docImage excludedMeta" content="images/booze.png"/>
+        <meta name="docImage" class="staticSearch.docImage" content="images/lookout.svg"/>
+    
         <!-- This exists to test the situation where there are documents for
              one side of the boolean but not for others. -->
         <meta name="Is a document" class="staticSearch.bool" content="true" />

--- a/xsl/json.xsl
+++ b/xsl/json.xsl
@@ -1025,7 +1025,7 @@
         <xsl:param name="doc" as="element(html)"/>
         <xsl:variable name="defaultTitle" select="normalize-space(string-join($doc//head/title[1]/descendant::text(),''))" as="xs:string?"/>
         <xsl:variable name="configuredDocTitle" 
-            select="$doc/head/meta[@name='docTitle'][contains-token(@class,'staticSearch.docTitle')]"
+            select="$doc/head/meta[@name='docTitle'][contains-token(@class,'staticSearch.docTitle')][not(@data-staticSearch-exclude)]"
             as="element(meta)*"/>
         <xsl:choose>
             <xsl:when test="exists($configuredDocTitle)">
@@ -1055,10 +1055,10 @@
     </xd:doc>
     <xsl:function name="hcmc:getDocThumbnail" as="element(j:string)?">
         <xsl:param name="doc" as="element(html)"/>
-        <xsl:variable name="docImage" select="$doc/head/meta[@name='docImage'][contains-token(@class,'staticSearch.docImage')]" 
+        <xsl:variable name="docImage" select="$doc/head/meta[@name='docImage'][contains-token(@class,'staticSearch.docImage')][not(@data-staticSearch-exclude)]" 
             as="element(meta)*"/>
         <xsl:variable name="docSortKey" 
-            select="$doc/head/meta[@name='docSortKey'][contains-token(@class,'staticSearch.docSortKey')]" 
+            select="$doc/head/meta[@name='docSortKey'][contains-token(@class,'staticSearch.docSortKey')][not(@data-staticSearch-exclude)]" 
             as="element(meta)*"/>
         <xsl:choose>
             <xsl:when test="exists($docImage)">
@@ -1081,11 +1081,12 @@
     <xsl:function name="hcmc:getDocSortKey" as="element(j:string)?">
         <xsl:param name="doc" as="element(html)"/>
         <xsl:variable name="docSortKey" 
-            select="$doc/head/meta[@name='docSortKey'][contains-token(@class,'staticSearch.docSortKey')]" 
+            select="$doc/head/meta[@name='docSortKey'][contains-token(@class,'staticSearch.docSortKey')][not(@data-staticSearch-exclude)]" 
             as="element(meta)*"/>
         <xsl:if test="exists($docSortKey)">
             <j:string><xsl:value-of select="$docSortKey[1]/@content"/></j:string>
         </xsl:if>
     </xsl:function>
+    
     
 </xsl:stylesheet>

--- a/xsl/json.xsl
+++ b/xsl/json.xsl
@@ -1024,12 +1024,15 @@
     <xsl:function name="hcmc:getDocTitle" as="xs:string">
         <xsl:param name="doc" as="element(html)"/>
         <xsl:variable name="defaultTitle" select="normalize-space(string-join($doc//head/title[1]/descendant::text(),''))" as="xs:string?"/>
-        <xsl:variable name="configuredDocTitle" 
+        <xsl:variable name="docTitle" 
             select="$doc/head/meta[@name='docTitle'][contains-token(@class,'staticSearch.docTitle')][not(@data-staticSearch-exclude)]"
             as="element(meta)*"/>
         <xsl:choose>
-            <xsl:when test="exists($configuredDocTitle)">
-                <xsl:value-of select="normalize-space($configuredDocTitle[1]/@content)"/>
+            <xsl:when test="exists($docTitle)">
+                <xsl:if test="count($docTitle) gt 1">
+                    <xsl:message>WARNING: Multiple docTitles declared in <xsl:value-of select="$doc/@data-staticSearch-relativeUri"/>. Using <xsl:value-of select="$docTitle[1]/@content"/></xsl:message>
+                </xsl:if>
+                <xsl:value-of select="normalize-space($docTitle[1]/@content)"/>
             </xsl:when>
             <xsl:when test="string-length($defaultTitle) gt 0">
                 <xsl:value-of select="$defaultTitle"/>
@@ -1062,6 +1065,9 @@
             as="element(meta)*"/>
         <xsl:choose>
             <xsl:when test="exists($docImage)">
+                <xsl:if test="count($docImage) gt 1">
+                    <xsl:message>WARNING: Multiple docImages declared in <xsl:value-of select="$doc/@data-staticSearch-relativeUri"/>. Using <xsl:value-of select="$docImage[1]/@content"/></xsl:message>
+                </xsl:if>
                 <j:string><xsl:value-of select="$docImage[1]/@content"/></j:string>
             </xsl:when>
             <xsl:when test="exists($docSortKey)">
@@ -1084,6 +1090,9 @@
             select="$doc/head/meta[@name='docSortKey'][contains-token(@class,'staticSearch.docSortKey')][not(@data-staticSearch-exclude)]" 
             as="element(meta)*"/>
         <xsl:if test="exists($docSortKey)">
+            <xsl:if test="count($docSortKey) gt 1">
+                <xsl:message>WARNING: Multiple docSortKeys declared in <xsl:value-of select="$doc/@data-staticSearch-relativeUri"/>. Using <xsl:value-of select="$docSortKey[1]/@content"/></xsl:message>
+            </xsl:if>
             <j:string><xsl:value-of select="$docSortKey[1]/@content"/></j:string>
         </xsl:if>
     </xsl:function>

--- a/xsl/json.xsl
+++ b/xsl/json.xsl
@@ -1018,14 +1018,18 @@
         <xd:desc><xd:ref name="hcmc:getDocTitle" type="function">hcmc:getDocTitle</xd:ref> is a simple function to retrieve 
                 the document title, which we may have to construct if there's nothing usable.</xd:desc>
         <xd:param name="doc">The input document, which must be an HTML element.</xd:param>
-        <xd:result>A string title, derived either from the document's actual title (preferable) or the document's @id if all else fails.</xd:result>
+        <xd:result>A string title, derived from the document's actual title, a configured document title,
+            or the document's @id if all else fails.</xd:result>
     </xd:doc>
     <xsl:function name="hcmc:getDocTitle" as="xs:string">
         <xsl:param name="doc" as="element(html)"/>
         <xsl:variable name="defaultTitle" select="normalize-space(string-join($doc//head/title[1]/descendant::text(),''))" as="xs:string?"/>
+        <xsl:variable name="configuredDocTitle" 
+            select="$doc/head/meta[@name='docTitle'][contains-token(@class,'staticSearch.docTitle')]"
+            as="element(meta)*"/>
         <xsl:choose>
-            <xsl:when test="$doc/head/meta[@name='docTitle'][@class='staticSearch.docTitle']">
-                <xsl:value-of select="normalize-space($doc/head/meta[@name='docTitle'][@class='staticSearch.docTitle'][1]/@content)"/>
+            <xsl:when test="exists($configuredDocTitle)">
+                <xsl:value-of select="normalize-space($configuredDocTitle[1]/@content)"/>
             </xsl:when>
             <xsl:when test="string-length($defaultTitle) gt 0">
                 <xsl:value-of select="$defaultTitle"/>
@@ -1051,11 +1055,16 @@
     </xd:doc>
     <xsl:function name="hcmc:getDocThumbnail" as="element(j:string)?">
         <xsl:param name="doc" as="element(html)"/>
+        <xsl:variable name="docImage" select="$doc/head/meta[@name='docImage'][contains-token(@class,'staticSearch.docImage')]" 
+            as="element(meta)*"/>
+        <xsl:variable name="docSortKey" 
+            select="$doc/head/meta[@name='docSortKey'][contains-token(@class,'staticSearch.docSortKey')]" 
+            as="element(meta)*"/>
         <xsl:choose>
-            <xsl:when test="$doc/head/meta[@name='docImage'][@class='staticSearch.docImage']">
-                <j:string><xsl:value-of select="$doc/head/meta[@name='docImage'][@class='staticSearch.docImage'][1]/@content"/></j:string>
+            <xsl:when test="exists($docImage)">
+                <j:string><xsl:value-of select="$docImage[1]/@content"/></j:string>
             </xsl:when>
-            <xsl:when test="$doc/head/meta[@name='docSortKey'][@class='staticSearch.docSortKey']">
+            <xsl:when test="exists($docSortKey)">
                 <j:string></j:string>
             </xsl:when>
         </xsl:choose>
@@ -1065,14 +1074,17 @@
         <xd:desc><xd:ref name="hcmc:getDocSortKey" type="function">hcmc:getDocSortKey</xd:ref> 
             generates a j:string element containing a string read
             from the meta[@name='ssDocSortKey'] element if there
-            is one, or the empty sequence if not..</xd:desc>
+            is one, or the empty sequence if not.</xd:desc>
         <xd:param name="doc">The input document, which must be an HTML element.</xd:param>
         <xd:result>A j:string element, if there is a configured sort key, or the empty sequence.</xd:result>
     </xd:doc>
     <xsl:function name="hcmc:getDocSortKey" as="element(j:string)?">
         <xsl:param name="doc" as="element(html)"/>
-        <xsl:if test="$doc/head/meta[@name='docSortKey'][@class='staticSearch.docSortKey']">
-            <j:string><xsl:value-of select="$doc/head/meta[@name='docSortKey'][@class='staticSearch.docSortKey'][1]/@content"/></j:string>
+        <xsl:variable name="docSortKey" 
+            select="$doc/head/meta[@name='docSortKey'][contains-token(@class,'staticSearch.docSortKey')]" 
+            as="element(meta)*"/>
+        <xsl:if test="exists($docSortKey)">
+            <j:string><xsl:value-of select="$docSortKey[1]/@content"/></j:string>
         </xsl:if>
     </xsl:function>
     


### PR DESCRIPTION
Adds some better handling for docTitle, docSortKey, and docImage metas:

* Allow staticSearch.(docTitle|docSortKey|docImage) as a token rather than as full value
* Check docTitle, docSortKey, and docImage meta tags to make sure they're declared properly (each name has a corresponding class value).
* Adds some examples in "Bad Things," which raises a warning. I was using it to make sure all of the warnings worked properly, but didn't think there'd be harm in keeping it (I don't believe the Jenkins build should have any issues with the WARNING, but, if it does, we can comment the bad example out)