### PR TITLE
Dictionary fixes

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -345,6 +345,8 @@
         </description>
         <echo message="Cleaning temporary directory..."/>
         <delete dir="${staticSearchDir}/temp"/>
+        <!--Added 2021-02-19: Remove the dictionary files-->
+        <delete dir="${staticSearchDir}/dicts"/>
     </target>
     
     

--- a/xsl/create_config_xsl.xsl
+++ b/xsl/create_config_xsl.xsl
@@ -320,7 +320,7 @@
                 <!--First, create the global variables and parameters-->
                 <xsl:call-template name="createGlobals" exclude-result-prefixes="#all"/>
                 
-                <!--Now create the DICTIONARY xml files-->
+                <!--Now create the dictionary XML files-->
                 <xsl:call-template name="createDictionaryXML" exclude-result-prefixes="#all"/>
                 
                 
@@ -514,7 +514,10 @@
         </xso:template>
     </xsl:template>
 
-    
+    <xd:doc>
+        <xd:desc>Template to create an XML representation of the dictionary file 
+        and an associated key.</xd:desc>
+    </xd:doc>
     <xsl:template name="createDictionaryXML" exclude-result-prefixes="xs xd tei">
         <xsl:for-each select="($configDoc//stopwordsFile, $configDoc//dictionaryFile)">
             <xsl:variable name="path" select="resolve-uri(text(),$configUri)"/>

--- a/xsl/create_reports.xsl
+++ b/xsl/create_reports.xsl
@@ -4,7 +4,8 @@
     xmlns:hcmc="http://hcmc.uvic.ca/ns/staticSearch"
     xmlns="http://www.w3.org/1999/xhtml"
     xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
-    xmlns:map="http://www.w3.org/2005/xpath-functions"
+    xmlns:j="http://www.w3.org/2005/xpath-functions"
+    xmlns:map="http://www.w3.org/2005/xpath-functions/map"
     exclude-result-prefixes="#all"
     xpath-default-namespace="http://www.w3.org/1999/xhtml"
     version="3.0">
@@ -14,10 +15,16 @@
             <xd:p><xd:b>Authors:</xd:b> Joey Takeda and Martin Holmes</xd:p>            
             <xd:p>This transformation, which is a utility transformation, creates various reports
                   from the search creation.</xd:p>
-          
         </xd:desc>
+        <xd:param name="hasFilters">Parameter, passed from the ant build, that specifies
+        whether filters have been created for the staticSearch.</xd:param>
     </xd:doc>
     
+    <!--**************************************************************
+       *                                                            *
+       *                         Includes                           *
+       *                                                            *
+       **************************************************************-->  
     <xd:doc>
         <xd:desc>Include the generated config file.</xd:desc>
     </xd:doc>
@@ -29,12 +36,25 @@
     <xsl:include href="functions.xsl"/>
     
     
+    <!--*************************************************************
+       *                                                            *
+       *                         Parameters                         *
+       *                                                            *
+       **************************************************************-->  
+    
     <xd:doc>
         <xd:desc><xd:ref name="hasFilters">$hasFilters</xd:ref> is used to specify whether
             the site build process has discovered any filter metadata in the collection. If so, then
             we need to create appropriate form controls.</xd:desc>
     </xd:doc>
     <xsl:param name="hasFilters" as="xs:string" select="'false'"/>
+
+
+    <!--**************************************************************
+       *                                                            *
+       *                         Output                             *
+       *                                                            *
+       **************************************************************-->  
     
     <xd:doc>
         <xd:desc>Output as XHTML with HTML version 5.0; this is necessary for adding the
@@ -42,8 +62,32 @@
     </xd:doc>
     <xsl:output method="xhtml" encoding="UTF-8" normalization-form="NFC"
         exclude-result-prefixes="#all" omit-xml-declaration="yes" html-version="5.0"/>
+
+
+    <!--**************************************************************
+       *                                                            *
+       *                         Variables                          *
+       *                                                            *
+       **************************************************************-->  
+    
+    <xd:doc>
+        <xd:desc><xd:ref name="spans" type="variable">$spans</xd:ref> are all of the
+        search tokens in the document collection, which we need for many of the different
+        reports.</xd:desc>
+    </xd:doc>
     <xsl:variable name="spans" select="$tokenizedDocs//span[@data-staticSearch-stem]"/>
     
+    
+    <!--*************************************************************
+       *                                                            *
+       *                         Parameters                         *
+       *                                                            *
+       **************************************************************-->  
+    
+    
+    <xd:doc>
+        <xd:desc>Root/driver template to create the reports</xd:desc>
+    </xd:doc>
     <xsl:template match="/">
         <xsl:message>Creating reports...this might take a while</xsl:message>
         <xsl:result-document href="{$ssBaseDir}/{$buildReportFilename}">
@@ -104,7 +148,6 @@
                         <xsl:call-template name="createExcludes"/>
                         <xsl:call-template name="createWordTables"/>
                         <xsl:call-template name="createNonDictionaryList"/>
-
                         <xsl:call-template name="createForeignWordList"/>
                     </div>
                 </body>
@@ -123,7 +166,6 @@
             <h2>Diagnostics</h2>
             <details>
                 <summary>Documents without html/@id (<xsl:value-of select="count($docsWithoutIds)"/>)</summary>
-   
                     <xsl:choose>
                         <xsl:when test="count($docsWithoutIds) gt 0">
                             <ul>
@@ -136,7 +178,6 @@
                             <p>None found!</p>
                         </xsl:otherwise>
                     </xsl:choose>
-                
             </details>
             <details>
                 <summary>Documents without html/@lang (<xsl:value-of select="count($docsWithoutLang)"/>)</summary>
@@ -152,10 +193,7 @@
                             <p>None found!</p>
                         </xsl:otherwise>
                     </xsl:choose>
-                
             </details>
-
-            
             <details>
                 <summary>Bad Numeric Filters (<xsl:value-of select="count($badNumericFilters)"/>)</summary>
                 <xsl:choose>
@@ -172,8 +210,6 @@
                                 
                             </xsl:for-each-group>
                         </ul>
-                  
-                        
                     </xsl:when>
                     <xsl:otherwise>
                         <p>None found!</p>
@@ -195,9 +231,13 @@
                    </xsl:choose>
                 </details>
             </xsl:if>
+            
         </section>
     </xsl:template>
- 
+    
+    <xd:doc>
+        <xd:desc>Template to provide information about filters used and possibly broken filters.</xd:desc>
+    </xd:doc>
     <xsl:template name="createFilters">
         <xsl:message>Generating report on search filters...</xsl:message>
         <section>
@@ -208,13 +248,26 @@
                 <xsl:when test="count($filterFiles) gt 0">
                     <details>
                         <summary>Total filters: <xsl:value-of select="count($filterFiles)"/></summary>
-                        <ul>
-                            <xsl:for-each select="$filterFiles">
-                                <xsl:variable name="jDoc" select="json-to-xml(unparsed-text(.))"/>
-                                <li>id: <xsl:value-of select="$jDoc//map:string[@key='filterId']"/>; type: <xsl:value-of select="replace($jDoc//map:string[@key='filterId'], '^ss([^\d]+)+\d+$', '$1')"/>; caption: "<xsl:value-of select="$jDoc//map:string[@key='filterName']"/>"</li>
-                            </xsl:for-each>
-                        </ul>
-                        
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>ID</th>
+                                    <th>Type</th>
+                                    <th>Caption</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                               <xsl:for-each select="$filterFiles">
+                                   <xsl:variable name="jDoc" select="json-to-xml(unparsed-text(.))"/>
+                                   <xsl:variable name="filterId" select="$jDoc//j:string[@key='filterId']"/>
+                                   <tr>
+                                       <td><xsl:value-of select="$filterId"/></td>
+                                       <td><xsl:value-of select="replace($filterId, '^ss([^\d]+)+\d+$', '$1')"/></td>
+                                       <td><xsl:value-of select="$jDoc//j:string[@key='filterName']"/></td>
+                                   </tr>
+                               </xsl:for-each>
+                            </tbody>
+                        </table>
                     </details>
                 </xsl:when>
                 <xsl:otherwise>
@@ -225,7 +278,9 @@
     </xsl:template>
     
  
-    
+    <xd:doc>
+        <xd:desc>Template to create a table of statistics about the document collection.</xd:desc>
+    </xd:doc>
     <xsl:template name="createStats">
         <xsl:message>Generating statistics...</xsl:message>
         <section>
@@ -233,30 +288,32 @@
             <table>
                 <tbody>
                     <tr>
-                        <td>Total HTML Documents Analyzed</td>
+                        <th>Total HTML Documents Analyzed</th>
                         <td><xsl:value-of select="count($docUris)"/></td>
                     </tr>
                     <xsl:if test="$hasExclusions">
                         <tr>
-                            <td>HTML Documents Excluded</td>
+                            <th>HTML Documents Excluded</th>
                             <td><xsl:value-of select="count($docUris) - count($tokenizedDocs)"/></td>
                         </tr>
                     </xsl:if>
  
                     <tr>
-                        <td>Total Tokens Stemmed</td>
+                        <th>Total Tokens Stemmed</th>
                         <td><xsl:value-of select="count($spans)"/></td>
                     </tr>
                     <tr>
-                        <td>Total Unique Tokens (= Number of JSON files created)</td>
+                        <th>Total Unique Tokens (= Number of JSON files created)</th>
                         <td><xsl:value-of select="count(distinct-values($spans/tokenize(@data-staticSearch-stem,'\s+')))"/></td>
                     </tr>
                 </tbody>
             </table>
         </section>
-        
     </xsl:template>
     
+    <xd:doc>
+        <xd:desc>Template to report on any documents/filters that have been excluded.</xd:desc>
+    </xd:doc>
     <xsl:template name="createExcludes">
         <xsl:message>Generating exclusion stats...</xsl:message>
         <xsl:if test="doc($configFile)//*:exclude">
@@ -304,9 +361,13 @@
                 </details>
             </section>
         </xsl:if>
-        
     </xsl:template>
     
+    <xd:doc>
+        <xd:desc>Template to create the word frequency table; this is useful
+        for determining if there are words that appear so frequently that they should
+        be stopwords, etc.</xd:desc>
+    </xd:doc>
     <xsl:template name="createWordTables">
         <xsl:message>Generating frequency tables...</xsl:message>
         <section>
@@ -316,12 +377,12 @@
                 <table>
                     <thead>
                         <tr>
-                            <td>Stem</td>
-                            <td>Total Instances</td>
-                            <td>Total Variants</td>
-                            <td>Variant List</td>
-                            <td>Number of Documents</td>
-                            <td>Average use per document</td>
+                            <th>Stem</th>
+                            <th>Total Instances</th>
+                            <th>Total Variants</th>
+                            <th>Variant List</th>
+                            <th>Number of Documents</th>
+                            <th>Average use per document</th>
                             <!--                        <td>Document List</td>-->
                         </tr>
                     </thead>
@@ -406,40 +467,122 @@
         
     </xsl:template>
     
-    
+    <xd:doc>
+        <xd:desc>Template for creating the "Not in Dictionary" list. While a term's exclusion
+        from the dictionary doesn't change the search results, this report is helpful for catching
+        typos in your document collection. </xd:desc>
+    </xd:doc>
     <xsl:template name="createNonDictionaryList">
         <xsl:message>Creating Not-in-Dictionary list...</xsl:message>
         <section>
             <h2>Words Not In Dictionary</h2>
             
-            <xsl:variable name="wordsNotInDictionary" as="xs:string*">
-                <xsl:for-each-group select="$spans" group-by="replace(lower-case(string(.)),'^[“”]|[“”]$','')">
-                    <xsl:if test="not(matches(current-grouping-key(),'\d'))">
-                        <xsl:if test="not(exists(key('w', current-grouping-key(), $dictionaryFileXml)))">
-                            <xsl:sequence select="current-grouping-key()"/>
-                        </xsl:if>
-                    </xsl:if>                   
-                </xsl:for-each-group>
+            <!--Only check stems that are words-->
+            <xsl:variable name="stemsToCheck" select="$spans[not(matches(@data-staticSearch-stem,'\d'))][not(hcmc:isForeign(.))]" as="element(span)*"/>
+            
+            <!--Retrieve the outermost spans so we don't include the nested spans from hyphenated terms 
+                (we process those a bit differently) -->
+            <xsl:variable name="outermostStems" select="outermost($stemsToCheck)" as="element(span)*"/>
+            
+            <xsl:variable name="wordsNotInDictionaryMap" as="map(xs:string, xs:integer)">
+                <xsl:map>
+                    <!--Group by whether or not it has descendant spans-->
+                    <xsl:for-each-group select="$outermostStems" group-by="exists(child::span[@data-staticSearch-stem])">
+                        <xsl:choose>
+                            <!--If this thing has child stems, it's a hyphenated construct
+                            and so we check each child term individually-->
+                            <xsl:when test="current-grouping-key()">
+                                <!--Now iterate through all of the hyphenated spans-->
+                                <xsl:for-each-group select="current-group()" group-by="string(.)">
+                                    <!--Stash the word-->                                
+                                    <xsl:variable name="term" select="current-grouping-key()"/>
+                                    <!--Stash the current context-->
+                                    <xsl:variable name="hyphenatedSpan" select="current-group()[1]" as="element(span)"/>
+                                    
+                                    <!--Not in dictionary spans-->
+                                    <xsl:variable name="words" 
+                                        select="for $s in $hyphenatedSpan/span[@data-staticSearch-stem] return lower-case(string($s))" 
+                                        as="xs:string*"/>
+                                    
+                                    <xsl:variable name="cleanedWords" 
+                                        select="for $w in $words return hcmc:cleanWordForStemming($w)"
+                                        as="xs:string*"/>
+                                    
+                                    <xsl:variable name="allTermsNotInDictionary" 
+                                        select="every $cw in $cleanedWords satisfies not(hcmc:isInDictionary($cw))" as="xs:boolean"/>
+                                    
+                                    <xsl:if test="$allTermsNotInDictionary">
+                                        <xsl:map-entry key="$term" select="count(current-group())"/>
+                                    </xsl:if>
+                                </xsl:for-each-group>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <!--Group by string value (so basically just distinct values)-->
+                                <xsl:for-each-group select="current-group()" group-by="hcmc:cleanWordForStemming(lower-case(string(.)))">
+                                    <xsl:variable name="word" select="current-grouping-key()" as="xs:string"/>
+                                    <xsl:if test="not(hcmc:isInDictionary($word))">
+                                        <xsl:map-entry key="$word" select="count(current-group())"/>
+                                    </xsl:if>
+                                </xsl:for-each-group>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:for-each-group>
+                </xsl:map>
             </xsl:variable>
             
-            <xsl:variable name="wordsNotInDictionaryCount" select="count($wordsNotInDictionary)" as="xs:integer"/>
+            
+            <xsl:variable name="wordsNotInDictionaryCount" select="map:size($wordsNotInDictionaryMap)" as="xs:integer"/>
             
             <details>
                 <summary>Total words not in dictionary: <xsl:value-of select="$wordsNotInDictionaryCount"/></summary>
-                
-                <xsl:if test="not(empty($wordsNotInDictionary))">
-                    <ul>
-                        <xsl:for-each select="$wordsNotInDictionary">
-                            <xsl:sort select="lower-case(.)"/>
-                            <li><xsl:value-of select="."/></li>
-                        </xsl:for-each>
-                    </ul>
-                </xsl:if>
+
+                <xsl:choose>
+                    <xsl:when test="$wordsNotInDictionaryCount = 0">
+                        <p>None found!</p>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Word</th>
+                                    <th>Instances</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <xsl:for-each select="map:keys($wordsNotInDictionaryMap)">
+                                    <xsl:sort select="$wordsNotInDictionaryMap(.)" order="descending"/>
+                                    <tr>
+                                        <td><xsl:value-of select="."/></td>
+                                        <td><xsl:value-of select="$wordsNotInDictionaryMap(.)"/></td>
+                                    </tr>
+                                </xsl:for-each>     
+                            </tbody>
+                        </table>
+                 
+                    </xsl:otherwise>
+                </xsl:choose>
             </details>
-            
         </section>
     </xsl:template>
     
+    <xd:doc>
+        <xd:desc><xd:ref name="hcmc:isInDictionary">hcmc:isInDictionary</xd:ref> checks
+        whether or not a word is in the provided dictionary. This is basically just a wrapper
+        around the key() function, but we take advantage of Saxon 10HE's memo-function capabilities
+        and cache the results.</xd:desc>
+        <xd:param name="word">The normalized and lower-cased word to check</xd:param>
+    </xd:doc>
+    <xsl:function name="hcmc:isInDictionary" new-each-time="no" as="xs:boolean">
+        <xsl:param name="word" as="xs:string"/>
+        <xsl:sequence select="exists(key('w', $word, $dictionaryFileXml))"/>
+    </xsl:function>
+    
+    <xd:doc>
+        <xd:desc>Template to create a report of all "foreign" words in the collection:
+        by foreign, we mean words that are in a language different from the declared root lang.
+        This has no bearing on the search results, but this is helpful for determining if there are
+        blocks of text in languages that you weren't expecting or thought you had excluded.</xd:desc>
+    </xd:doc>
     <xsl:template name="createForeignWordList">
         <xsl:message>Creating Foreign Word list...</xsl:message>
         <section>

--- a/xsl/functions.xsl
+++ b/xsl/functions.xsl
@@ -17,6 +17,48 @@
     </xd:desc>
   </xd:doc>
   
+  <!--**************************************************************
+       *                                                            *
+       *                         Variables                          *
+       *                                                            *
+       **************************************************************-->  
+  
+  <xd:doc>
+    <xd:desc>Various apostrophes for use in regexes across the processes.</xd:desc>
+  </xd:doc>
+  <xsl:variable name="curlyAposOpen">‘</xsl:variable>
+  <xsl:variable name="curlyAposClose">’</xsl:variable>
+  <xsl:variable name="straightSingleApos">'</xsl:variable>
+  <xsl:variable name="curlyDoubleAposOpen">“</xsl:variable>
+  <xsl:variable name="curlyDoubleAposClose">”</xsl:variable>
+  <xsl:variable name="straightDoubleApos">"</xsl:variable>
+  
+  <xsl:variable name="allSingleApos" 
+    select="($straightSingleApos, $curlyAposOpen, $curlyAposClose)"
+    as="xs:string+"/>
+  
+  <xsl:variable name="allSingleAposCharClassRex" 
+    select="'[' || string-join($allSingleApos) || ']'" 
+    as="xs:string"/>
+  
+  <xsl:variable name="allDoubleApos" 
+    select="($curlyDoubleAposClose, $curlyDoubleAposOpen, $straightDoubleApos)" 
+    as="xs:string+"/>
+  
+  <xsl:variable name="allDoubleAposCharClassRex"
+    select="'[' || string-join($allDoubleApos) || ']'"
+    as="xs:string"/>
+  
+  
+  <xsl:variable name="allApos" select="($allSingleApos, $allDoubleApos)" as="xs:string+"/>
+  
+  
+  <!--**************************************************************
+       *                                                           *
+       *                         Functions                         *
+       *                                                           *
+       *************************************************************-->  
+  
   <xd:doc>
     <xd:desc><xd:ref name="hcmc:makeNCName" type="function">hcmc:makeNCName</xd:ref>
     is designed to generate a valid NCName that can be used as an identifier from
@@ -70,7 +112,7 @@
     <xd:param name="node">The node to check.</xd:param>
     <xd:return>A boolean for whether or not the word is foreign.</xd:return>
   </xd:doc>
-  <xsl:function name="hcmc:isForeign" as="xs:boolean">
+  <xsl:function name="hcmc:isForeign" new-each-time="no" as="xs:boolean">
     <xsl:param name="node" as="node()"/>
     
     <!--Get the root HTML element-->
@@ -103,6 +145,27 @@
       </xsl:otherwise>
     </xsl:choose>            
   </xsl:function>
+  
+  
+  <xd:doc>
+    <xd:desc><xd:ref name="hcmc:cleanWordForStemming">hcmc:cleanWordForStemming</xd:ref> takes the input word
+      and tidies it up to make it more amenable for the stemming process.</xd:desc>
+    <xd:param name="word">The input word</xd:param>
+    <xd:return>A cleaned version of the word.</xd:return>
+  </xd:doc>
+  <xsl:function name="hcmc:cleanWordForStemming" as="xs:string">
+    <xsl:param name="word" as="xs:string"/>
+    <xsl:value-of select="
+      replace($word, $allDoubleAposCharClassRex, '') (: Remove all quotation marks :)
+      => replace($allSingleAposCharClassRex, $straightSingleApos) (: Normalize all apostrophes to straight :)
+      => replace('\.$','') (: Remove trailing period :)
+      => replace('^' || $straightSingleApos, '') (: Remove leading apostrope :)
+      => replace($straightSingleApos || '$', '') (: Remove trailing apostrophe :)
+      => translate('ſ','s') (: Normalize long-s to regular s :)
+      "/>
+  </xsl:function>
+  
+  
   
 
 </xsl:stylesheet>


### PR DESCRIPTION
This PR involves a number of small changes to do with the reports:

* Remove the `/dicts/` folder from being retained after the stemming processing (per #119 )
* Fixing and improving the "Not in Dictionary" check by checking hyphenated terms and adding a better table of words, forms, and instances. The biggest change this required, however, was moving the apostrophes into the functions file so the string normalization could be used by both tokenize.xsl and create_reports.xsl
* Fixing and improving the "Foreign Words" check by adding the word, instance, and the language that word appears under (`que` in the EMod set is a good example)
* Finally adding something for boolean filters with only one category (per #72 )
* And some small additions, amendments, and fixes to the `xd:doc`s
 

