### PR TITLE
Fix for hyphenation issue

### DIFF
--- a/test/badthings.html
+++ b/test/badthings.html
@@ -43,6 +43,9 @@
             
             <p>Another thing we need to test is the handling of short words. The word bf
             is not in the stopword list so it should be indexed.</p>
+            
+            <p>One type of out-stretched: out-stretcht</p>
+            <p>Another type of out-stretched: out-ſtretcht</p>
            
         </div>
     </body>

--- a/xsl/tokenize.xsl
+++ b/xsl/tokenize.xsl
@@ -665,7 +665,7 @@
         </xsl:if>
         
         <!--Check whether or not the word is hyphenated-->
-        <xsl:variable name="hyphenated" select="matches($word,'[A-Za-z]-[A-Za-z]')" as="xs:boolean"/>
+        <xsl:variable name="hyphenated" select="matches($cleanedWord,'[A-Za-z]-[A-Za-z]')" as="xs:boolean"/>
         <xsl:if test="$verbose">
             <xsl:message>hcmc:getStem: hyphenated: <xsl:value-of select="$hyphenated"/></xsl:message>
         </xsl:if>


### PR DESCRIPTION
From LEMDO: we should be checking the cleaned word to evaluate whether or not it's hyphenated, rather than the regular word.

Also adding out-stretcht (and its variants) to the bad things test set.