### PR TITLE
Issue 126 sanitize

### DIFF
--- a/configTest.xml
+++ b/configTest.xml
@@ -13,8 +13,8 @@
         <minWordLength>2</minWordLength>
         <!--NOTE: If phrasalSearch is set to TRUE, then
         maxContexts prop will be ignored-->
-        <maxKwicsToHarvest>3</maxKwicsToHarvest>
-        <maxKwicsToShow>3</maxKwicsToShow>
+        <maxKwicsToHarvest>5</maxKwicsToHarvest>
+        <maxKwicsToShow>5</maxKwicsToShow>
         <totalKwicLength>15</totalKwicLength>
         <kwicTruncateString>...</kwicTruncateString>
         <verbose>false</verbose>

--- a/test/badthings.html
+++ b/test/badthings.html
@@ -48,7 +48,8 @@
             <p>Another type of out-stretched: out-ſtretcht</p>
           
           <p>Now let's try some stuff that ought to be carefully sanitized 
-            during indexing. This word should not appear in bold in the results: &lt;b&gt;bold&lt;/b&gt;. Ditto here: \u003Cb\u003E bold \u003C/b\u003E.</p>
+            during indexing. This word should not appear in bold in the results: &lt;b&gt;bold&lt;/b&gt;. 
+            Ditto here: \u003Cb\u003E bold \u003C/b\u003E. Here we have some already-escaped ampersands &amp; &amp; &amp;amp; bold &amp;amp; &amp; stuff.</p>
            
         </div>
     </body>

--- a/test/badthings.html
+++ b/test/badthings.html
@@ -46,6 +46,9 @@
             
             <p>One type of out-stretched: out-stretcht</p>
             <p>Another type of out-stretched: out-ſtretcht</p>
+          
+          <p>Now let's try some stuff that ought to be carefully sanitized 
+            during indexing. This word should not appear in bold in the results: &lt;b&gt;bold&lt;/b&gt;. Ditto here: \u003Cb\u003E bold \u003C/b\u003E.</p>
            
         </div>
     </body>

--- a/test/search.html
+++ b/test/search.html
@@ -58,6 +58,9 @@
             numeric value</q> options should appear in ascending numeric order although they do not have a
          configured <code>@data-ssFilterSortKey</code> setting.</p>
       
+      
+      <p>For other ad-hoc tests of JSON sanitizing, search for the word "bold".</p>
+      
       <!-- 
              This is the div into which the JavaScript and page components required for the
              search are inserted during the build process. The contents of this div are replaced
@@ -68,7 +71,7 @@
       <div id="staticSearch"><script src="ssTest/ssStemmer.js"></script><script src="ssTest/ssSearch.js"></script><script>
                 var Sch;
                 window.addEventListener('load', function(){Sch = new StaticSearch();});
-            </script><form accept-charset="UTF-8" id="ssForm" data-allowphrasal="yes" data-allowwildcards="yes" data-minwordlength="2" data-scrolltotextfragment="no" data-maxkwicstoshow="3" data-resultsperpage="5" onsubmit="return false;" data-versionstring="_03d2eec" data-ssfolder="ssTest" data-kwictruncatestring="..." data-resultslimit="2000"><span class="ssQueryAndButton"><input type="text" id="ssQuery"/><button id="ssDoSearch">Search</button></span><span class="clearButton"><button id="ssClear">Clear</button></span><div class="ssDescFilters">
+            </script><form accept-charset="UTF-8" id="ssForm" data-allowphrasal="yes" data-allowwildcards="yes" data-minwordlength="2" data-scrolltotextfragment="no" data-maxkwicstoshow="5" data-resultsperpage="5" onsubmit="return false;" data-versionstring="_9141920" data-ssfolder="ssTest" data-kwictruncatestring="..." data-resultslimit="2000"><span class="ssQueryAndButton"><input type="text" id="ssQuery"/><button id="ssDoSearch">Search</button></span><span class="clearButton"><button id="ssClear">Clear</button></span><div class="ssDescFilters">
                <fieldset class="ssFieldset" title="Document type" id="ssDesc1">
                   <legend>Document type</legend>
                   <ul class="ssDescCheckboxList">

--- a/test/search.html
+++ b/test/search.html
@@ -68,13 +68,13 @@
       <div id="staticSearch"><script src="ssTest/ssStemmer.js"></script><script src="ssTest/ssSearch.js"></script><script>
                 var Sch;
                 window.addEventListener('load', function(){Sch = new StaticSearch();});
-            </script><form accept-charset="UTF-8" id="ssForm" data-allowphrasal="yes" data-allowwildcards="yes" data-minwordlength="2" data-scrolltotextfragment="no" data-maxkwicstoshow="3" data-resultsperpage="5" onsubmit="return false;" data-versionstring="_1d27010" data-ssfolder="ssTest" data-kwictruncatestring="..." data-resultslimit="2000"><span class="ssQueryAndButton"><input type="text" id="ssQuery"/><button id="ssDoSearch">Search</button></span><span class="clearButton"><button id="ssClear">Clear</button></span><div class="ssDescFilters">
+            </script><form accept-charset="UTF-8" id="ssForm" data-allowphrasal="yes" data-allowwildcards="yes" data-minwordlength="2" data-scrolltotextfragment="no" data-maxkwicstoshow="3" data-resultsperpage="5" onsubmit="return false;" data-versionstring="_03d2eec" data-ssfolder="ssTest" data-kwictruncatestring="..." data-resultslimit="2000"><span class="ssQueryAndButton"><input type="text" id="ssQuery"/><button id="ssDoSearch">Search</button></span><span class="clearButton"><button id="ssClear">Clear</button></span><div class="ssDescFilters">
                <fieldset class="ssFieldset" title="Document type" id="ssDesc1">
                   <legend>Document type</legend>
                   <ul class="ssDescCheckboxList">
-                     <li><input type="checkbox" title="Document type" value="Article extracts" id="ssDesc1_2" class="staticSearch.desc"/><label for="ssDesc1_2">Article extracts</label></li>
-                     <li><input type="checkbox" title="Document type" value="Documents with tables" id="ssDesc1_4" class="staticSearch.desc"/><label for="ssDesc1_4">Documents with tables</label></li>
-                     <li><input type="checkbox" title="Document type" value="Poems" id="ssDesc1_3" class="staticSearch.desc"/><label for="ssDesc1_3">Poems</label></li>
+                     <li><input type="checkbox" title="Document type" value="Article extracts" id="ssDesc1_4" class="staticSearch.desc"/><label for="ssDesc1_4">Article extracts</label></li>
+                     <li><input type="checkbox" title="Document type" value="Documents with tables" id="ssDesc1_3" class="staticSearch.desc"/><label for="ssDesc1_3">Documents with tables</label></li>
+                     <li><input type="checkbox" title="Document type" value="Poems" id="ssDesc1_2" class="staticSearch.desc"/><label for="ssDesc1_2">Poems</label></li>
                      <li><input type="checkbox" title="Document type" value="Site info files" id="ssDesc1_1" class="staticSearch.desc"/><label for="ssDesc1_1">Site info files</label></li>
                   </ul>
                </fieldset>
@@ -82,13 +82,13 @@
                   <legend>Random numeric value</legend>
                   <ul class="ssDescCheckboxList">
                      <li><input type="checkbox" title="Random numeric value" value="1" id="ssDesc2_1" class="staticSearch.desc"/><label for="ssDesc2_1">1</label></li>
-                     <li><input type="checkbox" title="Random numeric value" value="2" id="ssDesc2_2" class="staticSearch.desc"/><label for="ssDesc2_2">2</label></li>
-                     <li><input type="checkbox" title="Random numeric value" value="3" id="ssDesc2_8" class="staticSearch.desc"/><label for="ssDesc2_8">3</label></li>
-                     <li><input type="checkbox" title="Random numeric value" value="4" id="ssDesc2_5" class="staticSearch.desc"/><label for="ssDesc2_5">4</label></li>
-                     <li><input type="checkbox" title="Random numeric value" value="11" id="ssDesc2_3" class="staticSearch.desc"/><label for="ssDesc2_3">11</label></li>
-                     <li><input type="checkbox" title="Random numeric value" value="21" id="ssDesc2_7" class="staticSearch.desc"/><label for="ssDesc2_7">21</label></li>
-                     <li><input type="checkbox" title="Random numeric value" value="31" id="ssDesc2_4" class="staticSearch.desc"/><label for="ssDesc2_4">31</label></li>
-                     <li><input type="checkbox" title="Random numeric value" value="41" id="ssDesc2_6" class="staticSearch.desc"/><label for="ssDesc2_6">41</label></li>
+                     <li><input type="checkbox" title="Random numeric value" value="2" id="ssDesc2_5" class="staticSearch.desc"/><label for="ssDesc2_5">2</label></li>
+                     <li><input type="checkbox" title="Random numeric value" value="3" id="ssDesc2_3" class="staticSearch.desc"/><label for="ssDesc2_3">3</label></li>
+                     <li><input type="checkbox" title="Random numeric value" value="4" id="ssDesc2_2" class="staticSearch.desc"/><label for="ssDesc2_2">4</label></li>
+                     <li><input type="checkbox" title="Random numeric value" value="11" id="ssDesc2_7" class="staticSearch.desc"/><label for="ssDesc2_7">11</label></li>
+                     <li><input type="checkbox" title="Random numeric value" value="21" id="ssDesc2_8" class="staticSearch.desc"/><label for="ssDesc2_8">21</label></li>
+                     <li><input type="checkbox" title="Random numeric value" value="31" id="ssDesc2_6" class="staticSearch.desc"/><label for="ssDesc2_6">31</label></li>
+                     <li><input type="checkbox" title="Random numeric value" value="41" id="ssDesc2_4" class="staticSearch.desc"/><label for="ssDesc2_4">41</label></li>
                   </ul>
                </fieldset>
             </div>

--- a/xsl/json.xsl
+++ b/xsl/json.xsl
@@ -561,7 +561,7 @@
     <xsl:param name="inStr" as="xs:string?"/>
     <xsl:choose>
       <xsl:when test="$inStr">
-        <xsl:sequence select="replace($inStr,'&gt;', '&amp;gt;') => replace('&lt;', '&amp;lt;')"/>
+        <xsl:sequence select="replace($inStr, '&amp;', '&amp;amp;') => replace('&gt;', '&amp;gt;') => replace('&lt;', '&amp;lt;')"/>
       </xsl:when>
       <xsl:otherwise><xsl:sequence select="()"/></xsl:otherwise>
     </xsl:choose>

--- a/xsl/json.xsl
+++ b/xsl/json.xsl
@@ -547,9 +547,26 @@
             version of the mark element around it (the kwicTruncateString is added by the returnSnippet
             function)-->
         <xsl:sequence
-            select="$startSnippet || '&lt;mark&gt;' || $thisTerm || '&lt;/mark&gt;' || $endSnippet"/>
+          select="hcmc:sanitizeForJson($startSnippet) || '&lt;mark&gt;' || $thisTerm || '&lt;/mark&gt;' || hcmc:sanitizeForJson($endSnippet)"/>
     </xsl:function>
-    
+  
+  <xd:doc>
+    <xd:desc><xd:ref name="hcmc:sanitizeForJson">hcmc:sanitizeForJson</xd:ref> takes a string
+    input and escapes angle brackets so that actual tags cannot inadvertently find their way
+    into search result KWICs.</xd:desc>
+    <xd:param name="inStr" as="xs:string?">The string to escape</xd:param>
+    <xd:return>The escaped string</xd:return>
+  </xd:doc>
+  <xsl:function name="hcmc:sanitizeForJson" as="xs:string?">
+    <xsl:param name="inStr" as="xs:string?"/>
+    <xsl:choose>
+      <xsl:when test="$inStr">
+        <xsl:sequence select="replace($inStr,'&gt;', '&amp;gt;') => replace('&lt;', '&amp;lt;')"/>
+      </xsl:when>
+      <xsl:otherwise><xsl:sequence select="()"/></xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  
     
     <xd:doc>
         <xd:desc><xd:ref name="hcmc:returnSnippet">hcmc:returnSnippet</xd:ref> takes a sequence of nodes and constructs


### PR DESCRIPTION
I've tested everything I can dig up and imagine here, and the only addition to what you initially suggested that I can find is the escaping of ampersands, which should presumably help maintain the strict validity of the search page after KWICs are written to it. I believe that the only genuine risk concerns the potential injection of script tags, and that should now be impractical.