### PR TITLE
Catch cases where setting html element to 0 creates empty document and breaks the build per issue #125.

### DIFF
--- a/xsl/create_config_xsl.xsl
+++ b/xsl/create_config_xsl.xsl
@@ -575,6 +575,16 @@
             <xso:if test="$verbose">
                 <xso:message>Template #clean: Deleting <xso:value-of select="local-name(.)"/></xso:message>
             </xso:if>
+          <xso:if test="local-name() = 'html'">
+            <xso:message terminate="yes">
+*********************************************
+ERROR: You have specified a weight of 0 for 
+an html element, which will create an empty 
+output file and generate an error during 
+tokenization.
+*********************************************
+            </xso:message>
+          </xso:if>
         </xso:template>
     </xsl:template>
     


### PR DESCRIPTION
I tried to find a way to catch the empty document error during tokenize.xsl using xsl:try, but the documents are loaded during a collection() call which is a bit tricky to wrap. Instead, I just fail the build if any deletion template matches an html element, because that will certainly cause the error later anyway. A clear error message should be enough to solve the problem.

You can test this like I did by adding a rule that matches and html element and has a weight of 0.