### PR TITLE
Adding captions handling for #143 

### DIFF
--- a/xsl/captions.xsl
+++ b/xsl/captions.xsl
@@ -25,7 +25,10 @@
             },
         'fr': 
             map{
-                'ssDoSearch': 'Chercher'
+                'ssDoSearch': 'Chercher',
+                'ssSearching': 'En cours...',
+                'ssClear': 'Effacer',
+                'ssPoweredBy': 'Réalisé par'
             }
         }"/>
     

--- a/xsl/captions.xsl
+++ b/xsl/captions.xsl
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
+    xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+    xmlns:hcmc="http://hcmc.uvic.ca/ns/staticSearch"
+    xmlns:svg="http://www.w3.org/2000/svg"
+    xpath-default-namespace="http://www.w3.org/1999/xhtml"
+    xmlns="http://www.w3.org/1999/xhtml"
+    exclude-result-prefixes="#all"
+    version="3.0">
+    
+    <xd:doc>
+        <xd:desc>A map of captions to use for building the search page. We organize this
+        similarly to the Javascript, indexed by language first.</xd:desc>
+    </xd:doc>
+    <xsl:param name="captions" as="map(*)" select="map{
+        'en':
+            map{
+                'ssDoSearch': 'Search',
+                'ssSearching': 'Searching...',
+                'ssClear': 'Clear',
+                'ssPoweredBy': 'Powered by'
+            
+            },
+        'fr': 
+            map{
+                'ssDoSearch': 'Chercher'
+            }
+        }"/>
+    
+    
+    <xd:doc>
+        <xd:desc>Function to get a caption for the search page by language. If the caption doesn't
+        exist for a given language, we try to use the English one; if a caption doesn't exist
+        for the English, then we fail.</xd:desc>
+        <xd:param name="name">The name of the caption that we want to use.</xd:param>
+        <xd:param name="lang">The language code to use.</xd:param>
+    </xd:doc>
+    <xsl:function name="hcmc:getCaption">
+        <xsl:param name="name" as="xs:string"/>
+        <xsl:param name="lang" as="xs:string"/>
+        
+        <xsl:variable name="langToUse" 
+            select="if (string-length($lang) gt 0) then $lang else 'en'"
+        as="xs:string"/>
+        
+        <!--Get the default english caption set-->
+        <xsl:variable name="englishCaptionSet" 
+            select="$captions('en')" 
+            as="map(xs:string, xs:string)"/>
+        
+        <!--Get a caption set for the language, which may not exist-->
+        <xsl:variable name="thisCaptionSet" 
+            select="$captions($lang)"
+            as="map(xs:string, xs:string)?"/>
+        
+        <xsl:choose>
+            <xsl:when test="exists($thisCaptionSet) and map:contains($thisCaptionSet, $name)">
+                <xsl:sequence select="$thisCaptionSet($name)"/>
+            </xsl:when>
+            <xsl:when test="map:contains($englishCaptionSet, $name)">
+                <xsl:message>WARNING: No <xsl:value-of select="$name"/> caption available for lang <xsl:value-of select="$lang"/>. Using English caption instead.</xsl:message>
+                <xsl:sequence select="$englishCaptionSet($name)"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:message terminate="yes">ERROR: No caption found for <xsl:value-of select="$name"/> in any language.</xsl:message>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:function>
+    
+    
+    
+    
+    
+</xsl:stylesheet>

--- a/xsl/makeSearchPage.xsl
+++ b/xsl/makeSearchPage.xsl
@@ -30,6 +30,11 @@
         for more details.</xd:desc>
     </xd:doc>
     <xsl:include href="config.xsl"/>
+    
+    <xd:doc>
+        <xd:desc>Include the captions set and the associated function.</xd:desc>
+    </xd:doc>
+    <xsl:include href="captions.xsl"/>
 
     <!--**************************************************************
        *                                                            *
@@ -147,7 +152,24 @@
         in the header of document.</xd:desc>
     </xd:doc>
     <xsl:template match="div[@id='staticSearch']">
-
+        
+        <!--Get the language we should be using for retrieving captions, defaulting to 'en'
+            if no language is specified-->
+        <xsl:variable name="captionLang" as="xs:string">
+            <xsl:variable name="declaredLang" select="string(ancestor-or-self::*[@xml:lang or @lang][1]/(@xml:lang, @lang)[1])" as="xs:string?"/>
+            <xsl:choose>
+                <xsl:when test="exists($declaredLang)">
+                    <xsl:sequence select="$declaredLang"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:if test="$verbose">
+                        <xsl:message>WARNING: No language declared for div/@id='staticSearch' to determine captions. Using 'en' by default.</xsl:message>
+                    </xsl:if>
+                    <xsl:sequence select="'en'"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        
         <!--First, copy out the div-->
         <xsl:copy>
 
@@ -191,7 +213,7 @@
                     <!--<xsl:variable name="validationPattern" as="xs:string">\s*(.*([^\*\?\[\]\s]+[^\s]*){3})+\s*</xsl:variable>
                     <input type="text" id="ssQuery" pattern="{$validationPattern}"/>-->
                     <input type="text" id="ssQuery"/>
-                    <button id="ssDoSearch">Search</button>
+                    <button id="ssDoSearch"><xsl:sequence select="hcmc:getCaption('ssDoSearch', $captionLang)"/></button>
                 </span>
                 
                 <xsl:if test="not(empty($filterJSONURIs))">
@@ -201,7 +223,11 @@
                     <xsl:variable name="numFilters" select="$filterJSONURIs[matches(.,'ssNum\d+.*\.json')]"/>
                     
                     <!--If there are filters, then add a clear button-->
-                    <span class="clearButton"><button id="ssClear">Clear</button></span>
+                    <span class="clearButton">
+                        <button id="ssClear">
+                            <xsl:sequence select="hcmc:getCaption('ssClear', $captionLang)"/>
+                        </button>
+                    </span>
                     <!--First, handle the desc filters-->
                     <xsl:if test="not(empty($descFilters))">
                         <div class="ssDescFilters">
@@ -387,7 +413,9 @@
                         </div>
                     </xsl:if>
                     <span class="postFilterSearchBtn">
-                        <button id="ssDoSearch2">Search</button>
+                        <button id="ssDoSearch2">
+                            <xsl:sequence select="hcmc:getCaption('ssDoSearch', $captionLang)"/>
+                        </button>
                     </span>
                
                 </xsl:if>
@@ -395,7 +423,9 @@
             </form>
             
             <!-- Popup message to show that search is being done. -->
-            <div id="ssSearching">Searching...</div>
+            <div id="ssSearching">
+                <xsl:sequence select="hcmc:getCaption('ssSearching', $captionLang)"/>
+            </div>
 
             <!--And now create the results div in the document-->
             <div id="ssResults">
@@ -405,7 +435,9 @@
             <!-- Finally, we add our logo and powered-by message. -->
             <div id="ssPoweredBy">
                 
-                <p>Powered by</p> <a href="https://github.com/projectEndings/staticSearch"><xsl:apply-templates select="doc($svgLogoFile)" mode="svgLogo"/></a>
+                <p>
+                    <xsl:sequence select="hcmc:getCaption('ssPoweredBy', $captionLang)"/>
+                </p> <a href="https://github.com/projectEndings/staticSearch"><xsl:apply-templates select="doc($svgLogoFile)" mode="svgLogo"/></a>
             </div>
         </xsl:copy>
     </xsl:template>


### PR DESCRIPTION
Created a new captions.xsl file, which contains a map of all captions (organized by language, and then caption name, which is parallel to the way the JS works) and an associated function to get the caption for a given language. 

If a caption for a given language doesn't exist (either because the language isn't defined in the map or the language doesn't have that caption), then we use the English caption by default. If the caption key doesn't exist for any language, then the process simply fails. Tested with the test set, and all seems to work well--I added a single French caption, since that's about all I could reasonably figure out from my waning high-school knowledge of French, so the rest still need to be added.