### PR TITLE
Iss165 full fix

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -260,7 +260,7 @@
         includesfile="${staticSearchDir}/temp/patternset.txt" 
         excludes="**/staticSearch_report.html" 
         casesensitive="no"/>
-      <regexpmapper from="^(.*)\.([^.]+$)" to="\1_tokenized.html"/>
+      <regexpmapper from="^(.*)\.([^\.]+$)" to="\1_tokenized.html"/>
     </xslt>
   </target>
 

--- a/build.xml
+++ b/build.xml
@@ -260,7 +260,7 @@
         includesfile="${staticSearchDir}/temp/patternset.txt" 
         excludes="**/staticSearch_report.html" 
         casesensitive="no"/>
-      <globmapper from="*.html" to="*_tokenized.html"/>
+      <regexpmapper from="^(.*)\.([^.]+$)" to="\1_tokenized.html"/>
     </xslt>
   </target>
 

--- a/build.xml
+++ b/build.xml
@@ -214,7 +214,6 @@
         <include name="**/**.*htm*"/>
       </fileset>
     </xmlvalidate>
-
     <echo message="Validating ${ssConfigFile} against the staticSearch schema..."/>
     <exec executable="java" failonerror="false">
       <arg line="-jar ${ssBaseDir}/lib/jing.jar"/>
@@ -251,14 +250,8 @@
       XSLT module (generated in the config task) to determine the input files, et cetera. </description>
     <echo message="Creating tokenized XHTML files..."/>
     <loadfile srcFile="${staticSearchDir}/temp/patternset.txt" property="ptn" failonerror="true"/>
-    
- <!--   <echo message="pattern = ${ptn}"/>
-    <echo message="collection dir = ${ssCollectionDirName}"/>-->
-    <!-- NOTE that we need to set destdir for the xslt task, but we actually output result-documents, and the 
-         xslt task creates an empty document as well. We just put these empty documents in the empty folder 
-         and delete them at the end of the process pending a more elegant solution (see issue #165).-->
     <xslt
-      style="${ssBaseDir}/xsl/tokenize.xsl" classpath="${ssSaxon}" destdir="${staticSearchDir}/empty"
+      style="${ssBaseDir}/xsl/tokenize.xsl" classpath="${ssSaxon}" destdir="${staticSearchDir}/temp"
        reloadstylesheet="true"
        force="true"
       useimplicitfileset="false">
@@ -267,8 +260,8 @@
         includesfile="${staticSearchDir}/temp/patternset.txt" 
         excludes="**/staticSearch_report.html" 
         casesensitive="no"/>
+      <globmapper from="*.html" to="*_tokenized.html"/>
     </xslt>
-    <delete dir="${staticSearchDir}/empty"/>
   </target>
 
   <target name="json">

--- a/xsl/tokenize.xsl
+++ b/xsl/tokenize.xsl
@@ -118,7 +118,6 @@
     </xd:doc>
     <xsl:variable name="tokenRegex">(<xsl:value-of select="string-join(($numericWithDecimal,$hyphenatedWord,$alphanumeric),'|')"/>)</xsl:variable>
     
-    
     <xd:doc>
         <xd:desc>The document's URI as a string.</xd:desc>
     </xd:doc>
@@ -221,7 +220,7 @@
                 <xsl:for-each select="map:keys($outputMap)">
                     <xsl:result-document href="{replace(current-output-uri(),'_tokenized',('_' || .))}">
                         <xsl:message>Creating <xsl:value-of select="current-output-uri()"/></xsl:message>
-                        <xsl:copy-of select="$outputMap(.)"/>
+                        <xsl:copy-of select="map:get($outputMap, .)"/>
                     </xsl:result-document>
                 </xsl:for-each>
             </xsl:if>


### PR DESCRIPTION
This is the full fix for #165 (superfluous empty files); the file name handling is now done through ant via a mapper and the XSLT itself produces the correct output document (rather than creating a result-document and an empty file).

I also took it as a bit of an opportunity to clean up some artefacts of the collection approach for tokenization. In particular, I removed the tunnelled parameters since the variables could be made globally scoped. I also modified how the temporary verbose artifacts are produced to make it more streamlined.

