### PR TITLE
Iss197 dotsyntax

### DIFF
--- a/test/badthings.html
+++ b/test/badthings.html
@@ -5,25 +5,25 @@
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
         <title></title>
 
-        <meta name="Document type" class="staticSearch.desc" content="Site info files" data-ssFilterSortKey="W"/>
-        <meta name="Date range" class="staticSearch.date" content="2019" />
-        <meta name="Worth reading" class="staticSearch.bool" content="false" />
-        <meta name="Random numeric value" class="staticSearch.desc" content="1" />
-        <meta name="Number of animal names" class="staticSearch.num" content="6"/>
+        <meta name="Document type" class="staticSearch_desc" content="Site info files" data-ssFilterSortKey="W"/>
+        <meta name="Date range" class="staticSearch_date" content="2019" />
+        <meta name="Worth reading" class="staticSearch_bool" content="false" />
+        <meta name="Random numeric value" class="staticSearch_desc" content="1" />
+        <meta name="Number of animal names" class="staticSearch_num" content="6"/>
         <!--This has multiple docImages, but one is excluded-->
-        <meta name="docImage" class="staticSearch.docImage excludedMeta" content="images/booze.png"/>
-        <meta name="docImage" class="staticSearch.docImage" content="images/lookout.svg"/>
+        <meta name="docImage" class="staticSearch_docImage excludedMeta" content="images/booze.png"/>
+        <meta name="docImage" class="staticSearch_docImage" content="images/lookout.svg"/>
         
         <!--docTitle meta with no @class, which should raise a warning -->
         <meta name="docTitle" content="Bad Document Title"/>
         
         <!--Multiple docSortKeys-->
-        <meta name="docSortKey" class="staticSearch.docSortKey" content="aaa"/>
-        <meta name="docSortKey" class="staticSearch.docSortKey" content="zzz"/>
+        <meta name="docSortKey" class="staticSearch_docSortKey" content="aaa"/>
+        <meta name="docSortKey" class="staticSearch_docSortKey" content="zzz"/>
         
         <!-- This exists to test the situation where there are documents for
              one side of the boolean but not for others. -->
-        <meta name="Is a document" class="staticSearch.bool" content="true" />
+        <meta name="Is a document" class="staticSearch_bool" content="true" />
       
       <meta name="People involved" class="staticSearch_feat" content="Martin Holmes"/>
       <meta name="People involved" class="staticSearch_feat" content="Joey Takeda"/>

--- a/xsl/tokenize.xsl
+++ b/xsl/tokenize.xsl
@@ -306,44 +306,6 @@
     </xsl:template>
     
     <xd:doc>
-        <xd:desc>Template to check for the soon-to-be deprecated period syntax in class names; in all releases after 1.2,
-            staticSearch classes should use an underscore, not a period (i.e. staticSearch_desc).</xd:desc>
-    </xd:doc>
-    <xsl:template match="meta/@class[matches(.,'(^|\s)staticSearch\.')]" mode="clean">
-        <xsl:variable name="classes" select="tokenize(.)" as="xs:string+"/>
-        <xsl:attribute name="class" separator=" ">
-            <xsl:for-each select="$classes">
-                <xsl:variable name="currClass" select="." as="xs:string"/>
-                <xsl:choose>
-                    <xsl:when test="matches(.,'^staticSearch\.')">
-                        <xsl:variable name="ssType" select="substring-after($currClass,'staticSearch.')" as="xs:string"/>
-                        <xsl:choose>
-                            <!--Check to see if it's a valid filter or document meta,
-                                in which case we (currently) transform it into the new syntax
-                                for backwards compatibility-->
-                            <xsl:when test="$ssType = ($ssFilters, $docMetas)">
-                                <xsl:variable name="classWithUnderscore" select="translate($currClass,'.','_')" as="xs:string"/>
-                                <!--CHANGE TERMINATE TO YES AND CHANGE MESSAGE TO ERROR ONCE FULLY DEPRECATED-->
-                                <xsl:message terminate="no">WARNING: Deprecated meta/@class in <xsl:value-of select="$relativeUri"/> (<xsl:value-of select="$currClass"/>). The "staticSearch." syntax has been deprecated and will not be supported in the next version of staticSearch. Use <xsl:value-of select="$classWithUnderscore"/> instead.
-                                </xsl:message>
-                                <!--REMOVE THE FOLLOWING LINE AFTER DEPRECATION PERIOD-->
-                                <xsl:value-of select="$classWithUnderscore"/>
-                            </xsl:when>
-                            <xsl:otherwise>
-                                <!--TODO: Should we error if there a class isn't properly configured?-->
-                                <xsl:value-of select="$currClass"/>
-                            </xsl:otherwise>
-                        </xsl:choose>
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <xsl:value-of select="$currClass"/>
-                    </xsl:otherwise>
-                </xsl:choose>
-            </xsl:for-each>
-        </xsl:attribute>
-    </xsl:template>
-    
-    <xd:doc>
         <xd:desc>Template (added for release 1.4) to catch any instance of 
         @data-ssFilterSortKey, which should be @data-ssfiltersortkey per the 
         XHTML spec. This should be deprecated for version 1.4 and by invalid for


### PR DESCRIPTION
For #197: The dot syntax was deprecated in 1.2, so this drops all support for it (i.e. it will now silently be ignored). We should, however, add a check for the dot syntax in the schematron (#208)