### PR TITLE
Fix a 'mod 0' bug

### DIFF
--- a/xsl/json.xsl
+++ b/xsl/json.xsl
@@ -222,7 +222,7 @@
         </xsl:if>
         <xsl:message use-when="$verbose">Processing <xsl:value-of select="current-grouping-key()"/></xsl:message>
         <!--Figure out ten percent-->
-        <xsl:variable name="tenPercent" select="last() idiv 10"/>
+        <xsl:variable name="tenPercent" select="max((last() idiv 10, 1))"/>
         <!--Get the rough percentage-->
         <xsl:variable name="roughPercentage" select="position() idiv $tenPercent"/>
         <xsl:variable name="isLast" select="position() = last()"/>


### PR DESCRIPTION
The `makeTokenCounterMsg` template in `xsl/json.xsl` attempts to output messages only 10% of the time. Unfortunately, if there are fewer than 10 files, `last() idiv 10` is zero and `position() mod 0` is an error. This patch just forces the value to be 1 if there are fewer than 10 files.