### PR TITLE
Add RelaxNG Compact syntax schema for use with Emacs' 'nXML' mode.

### DIFF
--- a/schema/schemas.xml
+++ b/schema/schemas.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<!-- Schema locating rules for use with Emacs' 'nXML' mode. -->
+<locatingRules xmlns="http://thaiopensource.com/ns/locating-rules/1.0">
+  <namespace ns="http://hcmc.uvic.ca/ns/staticSearch" uri="staticSearch.rnc"/>
+</locatingRules>


### PR DESCRIPTION
I assume that you can do that similarly to how you create the RNG version.

This PR adds the 'Schema locating rules' so that Emacs can find the schema.

An Emacs user would add the path to `schemas.xml` to their `rng-schema-locating-files` variable in their `.emacs` file.