### PR TITLE
Oxygen framework for configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,8 +47,11 @@ config.xsl
 
 #Avoid including any generated zip distros.
 /staticSearch*.zip
+releases
 
 # Generated JS files
 js/ssSearch-debug.js
 js/ssSearch.js
 
+# Emacs backup files
+*~

--- a/EDITING.md
+++ b/EDITING.md
@@ -1,0 +1,45 @@
+# Editing Configuration XML Files
+
+The configuration file is an XML document which tells the Generator where to find your site, and what search features you would like to include.
+
+A configuration file can be edited with any text editor. Editing will be easier if you use an XML-aware editor that checks the XML syntax for you, and easier again if a schema-aware XML editor is configured to validate the XML file against the configuration file schema.
+
+Support for two schema-aware editors is provided: Oxygen and Emacs.
+
+## Oxygen framework
+
+The staticSearch framework can be installed either as add-on inside Oxygen or as files on the file system in a location where Oxygen can find them.
+
+### Installing as add-on Oxygen framework
+
+Follow the instructions in the Oxygen manual at https://www.oxygenxml.com/doc/ug-editor/topics/installing-and-updating-add-ons.html
+
+The staticSearch framework update site URL is https://raw.githubusercontent.com/tgraham-antenna/static-search/dev/add-on.xml
+
+Note that Oxygen will require you to restart the editor after installing the add-on framework.
+
+### Installing a ZIP archive to Oxygen `frameworks` directory
+
+1. Download the ZIP archive from the latest release on the 'Releases' page.
+2. Extract the folder in the ZIP archive to the Oxygen `frameworks` directory.
+ - On Windows, this is `C:\Program Files\Oxygen XML Editor 25\frameworks`, or something similar.
+ - If you don't have permission to copy the folder to the `frameworks` directory, then you can use an alternative location as described below.
+3. Restart Oxygen.
+
+### Installing a ZIP archive to an alternative frameworks location
+
+If you don't have permission to modify the Oxygen installation – for example, if Oxygen is installed on Windows under `C:\Program Files\` and you are not an Administrator – you can set Oxygen to also use an alternative frameworks location.
+
+1. Click on the "Download ZIP" button on this project's main page to download the files.
+2. Extract the folder in the ZIP archive to a folder where you can create the new folder.
+3. In your Oxygen preferences, add the staticSearch folder as an alternative frameworks location.
+ - See https://www.oxygenxml.com/doc/ug-editor/topics/framework-location.html
+4. Restart Oxygen.
+
+### Using the Oxygen framework
+
+When you open a configuration file – where the document element is `config` in the staticSearch namespace – Oxygen will automatically validate the document against the Relax NG schema.
+
+## Emacs
+
+Clone the repository or download and unzip a release then add the location of the `schema\schemas.xml` file to the `rng-schema-locating-files` variable in your `.emacs` file.

--- a/EDITING.md
+++ b/EDITING.md
@@ -14,7 +14,7 @@ The staticSearch framework can be installed either as add-on inside Oxygen or as
 
 Follow the instructions in the Oxygen manual at https://www.oxygenxml.com/doc/ug-editor/topics/installing-and-updating-add-ons.html
 
-The staticSearch framework update site URL is https://raw.githubusercontent.com/tgraham-antenna/static-search/dev/add-on.xml
+The staticSearch framework update site URL is https://raw.githubusercontent.com/tgraham-antenna/staticSearch/framework/add-on.xml
 
 Note that Oxygen will require you to restart the editor after installing the add-on framework.
 

--- a/add-on.xml
+++ b/add-on.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xt:extensions xmlns:xt="http://www.oxygenxml.com/ns/extension"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.oxygenxml.com/ns/extension http://www.oxygenxml.com/ns/extension/extensions.xsd">
+    <xt:extension id="staticSearch">
+        <xt:location href="https://github.com/tgraham-antenna/staticSearch/releases/download/v2.0.0alpha/staticSearch-framework-2.0.0alpha.zip"/>
+        <xt:version>2.0.0alpha</xt:version>
+        <xt:oxy_version>14.0+</xt:oxy_version>
+        <xt:type>framework</xt:type>
+        <xt:author>Martin Holmes and Joey Takeda</xt:author>
+        <xt:name>staticSearch</xt:name>
+        <xt:description xmlns="http://www.w3.org/1999/xhtml"><h1>staticSearch</h1>
+<p>A codebase to support a pure JSON search engine requiring no backend for any XHTML5 document collection.</p>
+
+<p>See <a href="https://github.com/projectEndings/staticSearch">https://github.com/projectEndings/staticSearch</a>.</p>
+	</xt:description>
+        <xt:license><![CDATA[The code is licensed under both MPL and BSD.]]></xt:license>
+    </xt:extension>
+</xt:extensions>

--- a/add-on.xml
+++ b/add-on.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://www.oxygenxml.com/ns/extension http://www.oxygenxml.com/ns/extension/extensions.xsd">
     <xt:extension id="staticSearch">
         <xt:location href="https://github.com/tgraham-antenna/staticSearch/releases/download/v2.0.0alpha/staticSearch-framework-2.0.0alpha.zip"/>
-        <xt:version>2.0.0alpha</xt:version>
+        <xt:version>2.0.0</xt:version>
         <xt:oxy_version>14.0+</xt:oxy_version>
         <xt:type>framework</xt:type>
         <xt:author>Martin Holmes and Joey Takeda</xt:author>

--- a/build.xml
+++ b/build.xml
@@ -39,11 +39,20 @@
        by an invoking ant process. -->
   <dirname property="ssBaseDir" file="${ant.file}"/>
 
+  <pathconvert property="ssBaseDir.converted" dirsep="/">
+    <path location="${ssBaseDir}" />
+    <!-- Ant under cygwin uses a lowercase drive letter, which some Java
+	 programs don't recognise as a drive letter, so translate. -->
+    <map from="c:" to="C:"/>
+    <map from="d:" to="D:"/>
+    <map from="e:" to="E:"/>
+  </pathconvert>
+
   <!-- Use the saxon in our lib folder. -->
-  <property name="ssSaxon" value="${ssBaseDir}/lib/saxon-he-10.jar"/>
+  <property name="ssSaxon" value="${ssBaseDir.converted}/lib/saxon-he-10.jar"/>
   
   <!-- Use the closure compiler in our lib folder. -->
-  <property name="ssClosure" value="${ssBaseDir}/lib/closure-compiler.jar"/>
+  <property name="ssClosure" value="${ssBaseDir.converted}/lib/closure-compiler.jar"/>
   <taskdef name="jscomp" classname="com.google.javascript.jscomp.ant.CompileTask" classpath="${ssClosure}"/>
   
   <!-- Normally we suppress warnings, but we may turn them ("verbose") on for testing. -->
@@ -61,7 +70,7 @@
   <property name="ssConfig" value="configTest.xml"/>
 
   <!--The full path to the configuration file. You can use either this or ssConfig. -->
-  <property name="ssConfigFile" value="${ssBaseDir}/${ssConfig}"/>
+  <property name="ssConfigFile" value="${ssBaseDir.converted}/${ssConfig}"/>
   
   <!-- Get the config file name in case it was passed as a full path. -->
   <basename property="ssConfigFileName" file="${ssConfigFile}"/>
@@ -69,6 +78,15 @@
   <!--The derived name of the configuration directory based off of the configuration
         file path-->
   <dirname property="configDir" file="${ssConfigFile}"/>
+
+  <pathconvert property="configDir.converted" dirsep="/">
+    <path location="${configDir}" />
+    <!-- Ant under cygwin uses a lowercase drive letter, which some Java
+	 programs don't recognise as a drive letter, so translate. -->
+    <map from="c:" to="C:"/>
+    <map from="d:" to="D:"/>
+    <map from="e:" to="E:"/>
+  </pathconvert>
 
   <!--Load the configuration file as a property file-->
   <xmlproperty file="${ssConfigFile}" keeproot="true"/>
@@ -81,10 +99,19 @@
   <property name="ssVerboseReport" value="false"/>
 
   <!--The path to the search page, relative to the configuration directory-->
-  <property name="ssSearchFilePath" location="${configDir}/${config.params.searchFile}"/>
+  <property name="ssSearchFilePath" value="${configDir.converted}/${config.params.searchFile}"/>
 
   <!--The name of the collection dir, derived from the search file-->
   <dirname property="ssCollectionDirName" file="${ssSearchFilePath}"/>
+
+  <pathconvert property="ssCollectionDirName.converted" dirsep="/">
+    <path location="${ssCollectionDirName}" />
+    <!-- Ant under cygwin uses a lowercase drive letter, which some Java
+	 programs don't recognise as a drive letter, so translate. -->
+    <map from="c:" to="C:"/>
+    <map from="d:" to="D:"/>
+    <map from="e:" to="E:"/>
+  </pathconvert>
 
   <!--Output folder, which is forked, depending on whether or not an output folder
         is specified in the configuration file-->
@@ -100,7 +127,7 @@
 
   <!--The directory for all of the static search assets (JSON files, Javascripts, et cetera).
         Note that the static search directory is placed directly within the collection directory-->
-  <property name="staticSearchDir" value="${ssCollectionDirName}/${ssOutputFolder}"/>
+  <property name="staticSearchDir" value="${ssCollectionDirName.converted}/${ssOutputFolder}"/>
   
   <!--The NAME of the temporary folder, which we treat as a constant-->
   <property name="staticSearchTempFolder" value="ssTemp"/>
@@ -117,7 +144,7 @@
   <!--The temporary search page, which is constructed by appending ssTemp_ to the search base name
         and placing that file in the collectionDir-->
   <property name="tempSearchPageOutput"
-    value="${ssCollectionDirName}/ssTemp_${ssSearchPageBasename}"/>
+    value="${ssCollectionDirName.converted}/ssTemp_${ssSearchPageBasename}"/>
 
 
   <!--****************************************************************
@@ -133,10 +160,10 @@
       deletes any previous results from an earlier build and then recreates the staticSearchDir,
       which is simply the parent directory of the search file specified in the config file. In the
       special case of the test, this target also generates the VERSION file. </description>
-    <echo message="Initializing staticSearch build using codebase in ${ssBaseDir}..."/>
+    <echo message="Initializing staticSearch build using codebase in ${ssBaseDir.converted}..."/>
     <echo message="Deleting old products..."/>
     <delete dir="temp"/>
-    <delete file="${ssBaseDir}/xsl/config.xsl"/>
+    <delete file="${ssBaseDir.converted}/xsl/config.xsl"/>
     <delete file="${tempSearchPageOutput}"/>
     <delete dir="${staticSearchDir}"/>
     <echo message="Creating new static search directory: ${staticSearchDir}"/>
@@ -150,12 +177,12 @@
     <if>
       <equals arg1="configTest.xml" arg2="${ssConfigFileName}"/>
       <then>
-        <delete file="${ssBaseDir}/test/VERSION"/>
+        <delete file="${ssBaseDir.converted}/test/VERSION"/>
         <exec executable="git">
           <arg value="rev-parse"/>
           <arg value="--short"/>
           <arg value="HEAD"/>
-          <redirector output="${ssBaseDir}/test/VERSION"/>
+          <redirector output="${ssBaseDir.converted}/test/VERSION"/>
         </exec>
       </then>
     </if>
@@ -167,7 +194,7 @@
     <if>
       <equals arg1="configTest.xml" arg2="${ssConfigFileName}"/>
       <then>
-        <copy file="${ssBaseDir}/test/search.htm_" tofile="${ssBaseDir}/test/search.html"/>
+        <copy file="${ssBaseDir.converted}/test/search.htm_" tofile="${ssBaseDir.converted}/test/search.html"/>
       </then>
     </if>
   </target>
@@ -180,11 +207,11 @@
       checks the config file and sees if it's invalid. We don't fail if it's invalid, though, since
       we must assume that some people just don't care: but raise the error anyway. 
     </description>
-    <echo message="Validating ${ssCollectionDirName} for well-formedness"/>
+    <echo message="Validating ${ssCollectionDirName.converted} for well-formedness"/>
     <!--@lenient='true' since we are only checking well-formedness-->
     <xmlvalidate lenient="true">
       <!--TODO: This should really validate the actual set of files, and not just any-->
-      <fileset dir="${ssCollectionDirName}" casesensitive="false">
+      <fileset dir="${ssCollectionDirName.converted}" casesensitive="false">
         <include name="**/**.*htm*"/>
         <!--Don't validate items that may be in a different staticSearch output-->
         <exclude name="**/${staticSearchTempFolder}/**"/>
@@ -193,8 +220,8 @@
     </xmlvalidate>
     <echo message="Validating ${ssConfigFile} against the staticSearch schema..."/>
     <exec executable="java" failonerror="false">
-      <arg line="-jar ${ssBaseDir}/lib/jing.jar"/>
-      <arg value="${ssBaseDir}/schema/staticSearch.rng"/>
+      <arg line="-jar ${ssBaseDir.converted}/lib/jing.jar"/>
+      <arg value="${ssBaseDir.converted}/schema/staticSearch.rng"/>
       <arg value="${ssConfigFile}"/>
     </exec>
   </target>
@@ -210,12 +237,12 @@
       parameter. </description>
     <echo message="Creating configuration file..."/>
     <java classpath="${ssSaxon}" classname="net.sf.saxon.Transform" failonerror="true" fork="true">
-      <arg value="-xsl:${ssBaseDir}/xsl/create_config_xsl.xsl"/>
-      <arg value="-s:${ssBaseDir}/xsl/create_config_xsl.xsl"/>
+      <arg value="-xsl:${ssBaseDir.converted}/xsl/create_config_xsl.xsl"/>
+      <arg value="-s:${ssBaseDir.converted}/xsl/create_config_xsl.xsl"/>
       <arg value="--suppressXsltNamespaceCheck:on"/>
-      <arg value="configFile=${ssConfigFile}"/>
+      <arg value="configFile=file:///${ssConfigFile}"/>
       <arg value="ssVerbose=${ssVerbose}"/>
-      <arg value="ssPatternsetFile=${ssPatternsetFile}"/>
+      <arg value="ssPatternsetFile=file:///${ssPatternsetFile}"/>
     </java>
   </target>
   
@@ -230,12 +257,12 @@
     <loadfile srcFile="${ssPatternsetFile}" property="ptn" failonerror="true"/>
 
     <xslt
-      style="${ssBaseDir}/xsl/tokenize.xsl" classpath="${ssSaxon}" destdir="${staticSearchTempDir}"
+      style="${ssBaseDir.converted}/xsl/tokenize.xsl" classpath="${ssSaxon}" destdir="${staticSearchTempDir}"
        reloadstylesheet="true" 
        force="true"
       useimplicitfileset="false">
       <factory name="net.sf.saxon.TransformerFactoryImpl"/>
-      <fileset id="siteFiles" dir="${ssCollectionDirName}" casesensitive="no">
+      <fileset id="siteFiles" dir="${ssCollectionDirName.converted}" casesensitive="no">
         <includesfile name="${ssPatternsetFile}"/>
         <!--Exclude the temporary directory's basename-->
         <exclude name="**/${staticSearchTempFolder}/**"/>
@@ -262,8 +289,8 @@
       time, depending on the size of the resource collection. </description>
     <echo message="Creating individual JSON files..."/>
     <java classpath="${ssSaxon}" classname="net.sf.saxon.Transform" failonerror="true" fork="true">
-      <arg value="-xsl:${ssBaseDir}/xsl/json.xsl"/>
-      <arg value="-s:${ssBaseDir}/xsl/json.xsl"/>
+      <arg value="-xsl:${ssBaseDir.converted}/xsl/json.xsl"/>
+      <arg value="-s:${ssBaseDir.converted}/xsl/json.xsl"/>
       <arg value="--suppressXsltNamespaceCheck:on"/>
     </java>
   </target>
@@ -296,7 +323,7 @@
             in the XSLT.-->
     <available type="dir" property="hasFilters" file="${staticSearchDir}/filters" value="true"/>
     <java classpath="${ssSaxon}" classname="net.sf.saxon.Transform" failonerror="true" fork="true">
-      <arg value="-xsl:${ssBaseDir}/xsl/makeSearchPage.xsl"/>
+      <arg value="-xsl:${ssBaseDir.converted}/xsl/makeSearchPage.xsl"/>
       <arg value="-s:${ssSearchFilePath}"/>
       <arg value="-o:${tempSearchPageOutput}"/>
       <arg value="hasFilters=${hasFilters}"/>
@@ -364,14 +391,14 @@
       </fileset>
     </resourcecount>
     <java classpath="${ssSaxon}" classname="net.sf.saxon.Transform" failonerror="true" fork="true">
-      <arg value="-xsl:${ssBaseDir}/xsl/create_reports.xsl"/>
-      <arg value="-s:${ssBaseDir}/xsl/create_reports.xsl"/>
+      <arg value="-xsl:${ssBaseDir.converted}/xsl/create_reports.xsl"/>
+      <arg value="-s:${ssBaseDir.converted}/xsl/create_reports.xsl"/>
       <arg value="--suppressXsltNamespaceCheck:on"/>
       <arg value="hasFilters=${hasFilters}"/>
       <arg value="stemFileCount=${stemFileCount}"/>
       <arg value="verboseReport=${ssVerboseReport}"/>
     </java>
-    <move file="${ssBaseDir}/staticSearch_report.html"
+    <move file="${ssBaseDir.converted}/staticSearch_report.html"
       tofile="${staticSearchDir}/staticSearch_report.html"/>
     <echo message="The build process has produced the following report: "/>
     <echo message="${staticSearchDir}/staticSearch_report.html"/>
@@ -390,8 +417,8 @@
     </description>
     <echo message="Creating document concordance..."/>
     <java classpath="${ssSaxon}" classname="net.sf.saxon.Transform" failonerror="true" fork="true">
-      <arg value="-xsl:${ssBaseDir}/xsl/create_concordance.xsl"/>
-      <arg value="-s:${ssBaseDir}/xsl/create_concordance.xsl"/>
+      <arg value="-xsl:${ssBaseDir.converted}/xsl/create_concordance.xsl"/>
+      <arg value="-s:${ssBaseDir.converted}/xsl/create_concordance.xsl"/>
       <arg value="-it:makeConcordance"/>
       <arg value="--suppressXsltNamespaceCheck:on"/>
     </java>
@@ -406,14 +433,14 @@
       the expanded debug version, and the CSS.
     </description>
     <copy todir="${staticSearchDir}/">
-      <fileset dir="${ssBaseDir}/js">
+      <fileset dir="${ssBaseDir.converted}/js">
         <include name="ssSearch.js"/>
         <include name="ssSearch.js.map"/>
         <include name="ssSearch-debug.js"/>
         <include name="ssHighlight.js"/>
         <include name="ssInitialize.js"/>
       </fileset>
-      <fileset dir="${ssBaseDir}/css">
+      <fileset dir="${ssBaseDir.converted}/css">
         <include name="ss**.css"/>
       </fileset>
     </copy>
@@ -430,10 +457,10 @@
     <!--Added 2021-02-19: Remove the dictionary files-->
     <delete dir="${staticSearchDir}/dicts"/>
     <!--Added 2021-03-17: Remove the JS build files. -->
-    <delete file="${ssBaseDir}/js/ssSearch.js"/>
-    <delete file="${ssBaseDir}/js/ssSearch-debug.js"/>
-    <delete file="${ssBaseDir}/search-debug.html"/>
-    <delete file="${ssBaseDir}/ssSearch-manual-debug.html"/>
+    <delete file="${ssBaseDir.converted}/js/ssSearch.js"/>
+    <delete file="${ssBaseDir.converted}/js/ssSearch-debug.js"/>
+    <delete file="${ssBaseDir.converted}/search-debug.html"/>
+    <delete file="${ssBaseDir.converted}/ssSearch-manual-debug.html"/>
   </target>
 
   <target name="buildJS">
@@ -445,8 +472,8 @@
       to create a compressed version for production use.
     </description>
     <echo message="Compiling JavaScript source code..."/>
-    <concat destfile="${ssBaseDir}/js/ssSearch-debug.js" encoding="UTF-8">
-      <filelist dir="${ssBaseDir}/js">
+    <concat destfile="${ssBaseDir.converted}/js/ssSearch-debug.js" encoding="UTF-8">
+      <filelist dir="${ssBaseDir.converted}/js">
         <file name="ssPreamble.js"/>
         <file name="ssUtilities.js"/>
         <file name="StaticSearch.js"/>
@@ -454,32 +481,32 @@
         <file name="XSet.js"/>
         <file name="SSTypeAhead.js"/>
       </filelist>
-      <fileset dir="${ssBaseDir}/stemmers/${ssStemmerFolder}">
+      <fileset dir="${ssBaseDir.converted}/stemmers/${ssStemmerFolder}">
         <include name="ssStemmer.js"/>
       </fileset>
     </concat>
     <!-- Note that we're currently suppressing warnings when compiling. -->
     <!--<jscomp compilationLevel="${ssClosureCompilationLevel}" warning="${ssClosureWarning}" 
       debug="false" languageOut="${ssClosureOutputSpec}"
-      output="${ssBaseDir}/js/ssSearch.js">
-      <sources dir="${ssBaseDir}/js">
+      output="${ssBaseDir.converted}/js/ssSearch.js">
+      <sources dir="${ssBaseDir.converted}/js">
         <file name="ssSearch-debug.js"/>
       </sources>
     </jscomp>-->
     <jscomp compilationLevel="${ssClosureCompilationLevel}" 
       warning="${ssClosureWarning}" 
       debug="false" languageOut="${ssClosureOutputSpec}" 
-      output="${ssBaseDir}/js/ssSearch.js"
+      output="${ssBaseDir.converted}/js/ssSearch.js"
       sourceMapFormat="V3"
       sourceMapLocationMapping="js/ssSearch-debug.js|ssSearch-debug.js"
-      sourceMapOutputFile="${ssBaseDir}/js/ssSearch.js.map"
+      sourceMapOutputFile="${ssBaseDir.converted}/js/ssSearch.js.map"
       >
-      <sources dir="${ssBaseDir}/js">
+      <sources dir="${ssBaseDir.converted}/js">
         <file name="ssSearch-debug.js"/>
       </sources>
     </jscomp>
     <echo message="Adding source map comment to the end of the ssSearch.js file..."/>
-    <echo file="${ssBaseDir}/js/ssSearch.js" append="true">&#x0a;//# sourceMappingURL=ssSearch.js.map</echo>
+    <echo file="${ssBaseDir.converted}/js/ssSearch.js" append="true">&#x0a;//# sourceMappingURL=ssSearch.js.map</echo>
   </target>
 
   <target name="all"
@@ -514,6 +541,12 @@
       TARGET: basic
       Target that runs the whole process other than the report creation.
     </description>
+  </target>
+
+  <!-- Utility targets. -->
+
+  <target name="echoproperties">
+    <echoproperties />
   </target>
 
 </project>

--- a/build.xml
+++ b/build.xml
@@ -2,7 +2,7 @@
 <project basedir="." name="BuildStaticSearch" default="all" xmlns:if="ant:if"
   xmlns:unless="ant:unless">
 
-  <!-- 
+  <!--
         **********************************************************
         *  Ant file for building a static search engine for a    *
         *  specific site. When supplied with a config file path  *
@@ -50,19 +50,19 @@
 
   <!-- Use the saxon in our lib folder. -->
   <property name="ssSaxon" value="${ssBaseDir.converted}/lib/saxon-he-10.jar"/>
-  
+
   <!-- Use the closure compiler in our lib folder. -->
   <property name="ssClosure" value="${ssBaseDir.converted}/lib/closure-compiler.jar"/>
   <taskdef name="jscomp" classname="com.google.javascript.jscomp.ant.CompileTask" classpath="${ssClosure}"/>
-  
+
   <!-- Normally we suppress warnings, but we may turn them ("verbose") on for testing. -->
   <property name="ssClosureWarning" value="quiet"/>
-  
+
   <!-- Normally we stick to simple optimizations, but the user may wish to override
        in search of performance. WARNING: setting compilation level to ADVANCED seems
        to break it completely. -->
   <property name="ssClosureCompilationLevel" value="SIMPLE"/>
-  
+
   <!-- What output conformity we want for our JS. We're fairly forward-looking by default. -->
   <property name="ssClosureOutputSpec" value="ECMASCRIPT_2019"/>
 
@@ -71,7 +71,7 @@
 
   <!--The full path to the configuration file. You can use either this or ssConfig. -->
   <property name="ssConfigFile" value="${ssBaseDir.converted}/${ssConfig}"/>
-  
+
   <!-- Get the config file name in case it was passed as a full path. -->
   <basename property="ssConfigFileName" file="${ssConfigFile}"/>
 
@@ -93,8 +93,8 @@
 
   <!--Set the verbose flag to false by default; set to true to see detailed messages-->
   <property name="ssVerbose" value="false"/>
-  
-  <!--Set the verboseReport flag to false by default; set to true to allow the report 
+
+  <!--Set the verboseReport flag to false by default; set to true to allow the report
       generation process to create an exhaustive report (may trigger out-of-memory errors). -->
   <property name="ssVerboseReport" value="false"/>
 
@@ -128,13 +128,13 @@
   <!--The directory for all of the static search assets (JSON files, Javascripts, et cetera).
         Note that the static search directory is placed directly within the collection directory-->
   <property name="staticSearchDir" value="${ssCollectionDirName.converted}/${ssOutputFolder}"/>
-  
+
   <!--The NAME of the temporary folder, which we treat as a constant-->
   <property name="staticSearchTempFolder" value="ssTemp"/>
-  
+
   <!--The temporary directory for staticSearch to put tokenized files etc-->
   <property name="staticSearchTempDir" value="${staticSearchDir}/${staticSearchTempFolder}"/>
-  
+
   <!--Property for the name of the pattern set for use in staticSearch-->
   <property name="ssPatternsetFile" value="${staticSearchTempDir}/patternset.txt"/>
 
@@ -169,7 +169,7 @@
     <echo message="Creating new static search directory: ${staticSearchDir}"/>
     <mkdir dir="${staticSearchDir}"/>
 
-    <echo>Running staticSearch build based on config file: 
+    <echo>Running staticSearch build based on config file:
     ${ssConfigFile}</echo>
 
     <!-- If we're building the test data, we need to generate the VERSION file
@@ -186,9 +186,9 @@
         </exec>
       </then>
     </if>
-    <!-- If this build is our test suite, then we need to copy the 
+    <!-- If this build is our test suite, then we need to copy the
       template file for the search page (*.htm_) to its output file (*.html) so the
-      build process can use it. This enables us to avoid a constantly-changing 
+      build process can use it. This enables us to avoid a constantly-changing
       .html file that causes endless merge conflicts.
     -->
     <if>
@@ -205,7 +205,7 @@
       Task to validate that the source XHTML is well-formed XHTML. Note that this DOES
       NOT check whether or not it is valid XHTML: only that it is well-formed. This target also
       checks the config file and sees if it's invalid. We don't fail if it's invalid, though, since
-      we must assume that some people just don't care: but raise the error anyway. 
+      we must assume that some people just don't care: but raise the error anyway.
     </description>
     <echo message="Validating ${ssCollectionDirName.converted} for well-formedness"/>
     <!--@lenient='true' since we are only checking well-formedness-->
@@ -245,7 +245,7 @@
       <arg value="ssPatternsetFile=file:///${ssPatternsetFile}"/>
     </java>
   </target>
-  
+
   <target name="tokenize">
     <description>
       TARGET: tokenize
@@ -258,7 +258,7 @@
 
     <xslt
       style="${ssBaseDir.converted}/xsl/tokenize.xsl" classpath="${ssSaxon}" destdir="${staticSearchTempDir}"
-       reloadstylesheet="true" 
+       reloadstylesheet="true"
        force="true"
       useimplicitfileset="false">
       <factory name="net.sf.saxon.TransformerFactoryImpl"/>
@@ -270,7 +270,7 @@
 
        <regexpmapper from="^(.*)\.([^\.]+$)" to="\1_tokenized.html"/>
     </xslt>
-    <!--Necessary to delete any empty files (i.e. files excluded by 
+    <!--Necessary to delete any empty files (i.e. files excluded by
         the configuration) -->
     <delete verbose="${ssVerbose}">
       <fileset dir="${staticSearchTempDir}">
@@ -318,7 +318,7 @@
 
     <echo message="Creating temporary search page: ${tempSearchPageOutput}"/>
 
-    <!--We create a hasFilters property here since the search page needs to know whether or not there are filters to 
+    <!--We create a hasFilters property here since the search page needs to know whether or not there are filters to
             inject into the page. It is more efficient to derive the existence of the filters directory here rather than
             in the XSLT.-->
     <available type="dir" property="hasFilters" file="${staticSearchDir}/filters" value="true"/>
@@ -335,15 +335,15 @@
     <move file="${tempSearchPageOutput}" tofile="${ssSearchFilePath}"/>
 
   </target>
-  
+
   <target name="makeDebugSearchPage">
     <description>
       TARGET: makeDebugSearchPage
       This copies the newly-produced search page to a new file
-      and then replaces the link to ssSearch.js with one to 
+      and then replaces the link to ssSearch.js with one to
       ssSearch-debug.js, for better testing.
     </description>
-    <propertyregex property="ssDebugSearchPage" 
+    <propertyregex property="ssDebugSearchPage"
                    input="${ssSearchFilePath}"
                    regexp="(\.[a-zA-Z]+)$"
                    replace="-debug\1"
@@ -352,17 +352,17 @@
     <copy file="${ssSearchFilePath}" tofile="${ssDebugSearchPage}"/>
     <replace file="${ssDebugSearchPage}" token="ssSearch.js" value="ssSearch-debug.js"/>
   </target>
-  
+
   <target name="makeManualDebugSearchPage">
     <description>
       TARGET: makeManualDebugSearchPage
       This copies the newly-produced search page to a new file
-      and then replaces the link to ssSearch.js with one to 
+      and then replaces the link to ssSearch.js with one to
       ssSearch-debug.js, for better testing, but also removes the
       link to the test set, so that the search page has no activity
       on load and can be used for manual testing and debugging.
     </description>
-    <propertyregex property="ssManualDebugSearchPage" 
+    <propertyregex property="ssManualDebugSearchPage"
       input="${ssSearchFilePath}"
       regexp="(\.[a-zA-Z]+)$"
       replace="-manual-debug\1"
@@ -381,7 +381,7 @@
       statistics that track word use, et cetera. The XSLT is run on itself and creates a result
       document passed off of a path specified in the config file; the resulting HTML file for the
       report will be in the staticSearchDir. </description>
-    <!--We create a hasFilters property here since the search page needs to know whether or not there are filters to 
+    <!--We create a hasFilters property here since the search page needs to know whether or not there are filters to
             inject into the page. It is more efficient to derive the existence of the filters directory here rather than
             in the XSLT.-->
     <available type="dir" property="hasFilters" file="${staticSearchDir}/filters" value="true"/>
@@ -404,14 +404,14 @@
     <echo message="${staticSearchDir}/staticSearch_report.html"/>
     <echo message="Check the report to see any anomalies or problems found."/>
   </target>
-  
+
   <target name="concordance" depends="config">
     <description>
       TARGET: concordance
-      This target creates a concordance/wordlist for a document collection. 
+      This target creates a concordance/wordlist for a document collection.
       It is not run by default, since it is not necessary for staticSearch functionality
       but is useful for diagnosing potential stopwords or typos in the document collection.
-      
+
       It depends on the config task, since it needs the proper config XSLT to be produced
       from a specific config file.
     </description>
@@ -429,7 +429,7 @@
       TARGET: copyFiles
       This target copies the necessary Javascript and CSS files from
       the staticSearch directory (i.e. this directory) and places them in the project's static
-      search directory. We copy the compiled JS file which contains everything, along with 
+      search directory. We copy the compiled JS file which contains everything, along with
       the expanded debug version, and the CSS.
     </description>
     <copy todir="${staticSearchDir}/">
@@ -450,7 +450,7 @@
     <description>
       TARGET: clean
       This target deletes the temporary directory, since it's no longer
-      useful. 
+      useful.
     </description>
     <echo message="Cleaning temporary directory..."/>
     <delete dir="${staticSearchDir}/${staticSearchTempFolder}"/>
@@ -486,16 +486,16 @@
       </fileset>
     </concat>
     <!-- Note that we're currently suppressing warnings when compiling. -->
-    <!--<jscomp compilationLevel="${ssClosureCompilationLevel}" warning="${ssClosureWarning}" 
+    <!--<jscomp compilationLevel="${ssClosureCompilationLevel}" warning="${ssClosureWarning}"
       debug="false" languageOut="${ssClosureOutputSpec}"
       output="${ssBaseDir.converted}/js/ssSearch.js">
       <sources dir="${ssBaseDir.converted}/js">
         <file name="ssSearch-debug.js"/>
       </sources>
     </jscomp>-->
-    <jscomp compilationLevel="${ssClosureCompilationLevel}" 
-      warning="${ssClosureWarning}" 
-      debug="false" languageOut="${ssClosureOutputSpec}" 
+    <jscomp compilationLevel="${ssClosureCompilationLevel}"
+      warning="${ssClosureWarning}"
+      debug="false" languageOut="${ssClosureOutputSpec}"
       output="${ssBaseDir.converted}/js/ssSearch.js"
       sourceMapFormat="V3"
       sourceMapLocationMapping="js/ssSearch-debug.js|ssSearch-debug.js"
@@ -531,7 +531,7 @@
     <description>
       TARGET: test
       Target that runs the whole process, but does not clean up the
-      temporary files. Also creates debug/testing version of the 
+      temporary files. Also creates debug/testing version of the
       search page. Useful for debugging. </description>
   </target>
 
@@ -543,10 +543,70 @@
     </description>
   </target>
 
+  <!-- Oxygen framework targets. -->
+
+  <property name="edition.file" value="${ssBaseDir.converted}/EDITION" />
+  <loadfile property="edition" srcfile="${edition.file}"/>
+  <!-- Whether to force processing to run. -->
+  <property name="force" value="no" />
+
+  <target name="add-on.xml.uptodate">
+    <condition property="add-on.xml.uptodate">
+      <and>
+	<!-- File containing edition number. -->
+	<uptodate srcfile="${edition.file}"
+		  targetfile="${ssBaseDir.converted}/add-on.xml" />
+	<isfalse value="${force}" />
+      </and>
+    </condition>
+  </target>
+
+  <target name="add-on.xml" depends="add-on.xml.uptodate"
+	  unless="add-on.xml.uptodate"
+	  description="Update the edition information in 'add-on.xml'.">
+    <replaceregexp file="${ssBaseDir.converted}/add-on.xml"
+		   encoding="UTF-8">
+      <regexp pattern="&lt;xt:version>[^&lt;]+&lt;/xt:version>" />
+      <substitution expression="&lt;xt:version>${edition}&lt;/xt:version>"/>
+    </replaceregexp>
+    <replaceregexp file="${ssBaseDir.converted}/add-on.xml"
+		   encoding="UTF-8">
+      <regexp pattern='releases/download/[^"]+' />
+      <substitution
+	  expression="releases/download/v${edition}/staticSearch-framework-${edition}.zip"/>
+    </replaceregexp>
+    <tstamp>
+      <format property="year" pattern="yyyy" />
+    </tstamp>
+    <replaceregexp file="${ssBaseDir.converted}/add-on.xml"
+		   encoding="UTF-8">
+      <regexp pattern='Copyright ([0-9]+)-[0-9]+' />
+      <substitution
+	  expression="Copyright \1-${year}"/>
+    </replaceregexp>
+  </target>
+
+  <target name="framework.zip" depends="add-on.xml"
+	  description="Make a Zip archive of just the oXygen framework.">
+    <mkdir dir="${ssBaseDir.converted}/releases" />
+    <zip destfile="${ssBaseDir.converted}/releases/staticSearch-framework-${edition}.zip"
+	 basedir="${ssBaseDir.converted}"
+	 excludes="**"
+	 update="true">
+      <zipfileset dir="."
+		  includes="README.md, LICENSE, license_BSD.txt, staticSearch.framework"
+		  prefix="staticSearch" />
+      <zipfileset dir="schema" includes="*.rng, *.sch"
+		  prefix="staticSearch/schema" />
+      <zipfileset dir="templates" includes="*.xml, *.properties"
+		  prefix="staticSearch/templates" />
+    </zip>
+  </target>
+
   <!-- Utility targets. -->
 
   <target name="echoproperties">
-    <echoproperties />
+    <echoproperties/>
   </target>
 
 </project>

--- a/build.xml
+++ b/build.xml
@@ -545,8 +545,14 @@
 
   <!-- Oxygen framework targets. -->
 
-  <property name="edition.file" value="${ssBaseDir.converted}/EDITION" />
+  <property name="edition.file" value="${ssBaseDir.converted}/EDITION"/>
   <loadfile property="edition" srcfile="${edition.file}"/>
+  <loadfile property="add-on.version" srcfile="${edition.file}">
+    <filterchain>
+      <replaceregex pattern="^(\d+\.\d+\.\d+).*" replace="\1"/>
+    </filterchain>
+  </loadfile>
+    
   <!-- Whether to force processing to run. -->
   <property name="force" value="no" />
 
@@ -567,7 +573,7 @@
     <replaceregexp file="${ssBaseDir.converted}/add-on.xml"
 		   encoding="UTF-8">
       <regexp pattern="&lt;xt:version>[^&lt;]+&lt;/xt:version>" />
-      <substitution expression="&lt;xt:version>${edition}&lt;/xt:version>"/>
+      <substitution expression="&lt;xt:version>${add-on.version}&lt;/xt:version>"/>
     </replaceregexp>
     <replaceregexp file="${ssBaseDir.converted}/add-on.xml"
 		   encoding="UTF-8">

--- a/staticSearch.framework
+++ b/staticSearch.framework
@@ -1,0 +1,344 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<serialized xml:space="preserve">
+	<serializableOrderedMap>
+		<entry>
+			<String>document.types</String>
+			<documentTypeDescriptor-array>
+				<documentTypeDescriptor>
+					<field name="webResources">
+						<null/>
+					</field>
+					<field name="extensionPatch">
+						<null/>
+					</field>
+					<field name="name">
+						<String>staticSearch configuration</String>
+					</field>
+					<field name="schemaDescriptor">
+						<docTypeSchema>
+							<field name="type">
+								<Integer>4</Integer>
+							</field>
+							<field name="uri">
+								<String>${framework}/schema/staticSearch.rng</String>
+							</field>
+						</docTypeSchema>
+					</field>
+					<field name="classpath">
+						<String-array/>
+					</field>
+					<field name="parentClassLoaderID">
+						<null/>
+					</field>
+					<field name="authorExtensionDescriptor">
+						<authorExtension>
+							<field name="cssDescriptors">
+								<cssFile-array/>
+							</field>
+							<field name="mergeCSSsFromDocument">
+								<Boolean>false</Boolean>
+							</field>
+							<field name="multipleAlternateSelectionEnabled">
+								<Boolean>false</Boolean>
+							</field>
+							<field name="actionDescriptors">
+								<action-array/>
+							</field>
+							<field name="menubarDescriptor">
+								<menu>
+									<field name="label">
+										<String>Menu</String>
+									</field>
+									<field name="accessKey">
+										<null/>
+									</field>
+									<field name="iconPath">
+										<null/>
+									</field>
+									<field name="menuEntriesDescriptorList">
+										<menuEntry-array/>
+									</field>
+									<field name="context">
+										<null/>
+									</field>
+								</menu>
+							</field>
+							<field name="popupMenuDescriptor">
+								<menu>
+									<field name="label">
+										<String>Contextual menu</String>
+									</field>
+									<field name="accessKey">
+										<null/>
+									</field>
+									<field name="iconPath">
+										<null/>
+									</field>
+									<field name="menuEntriesDescriptorList">
+										<menuEntry-array/>
+									</field>
+									<field name="context">
+										<null/>
+									</field>
+								</menu>
+							</field>
+							<field name="toolbarDescriptor">
+								<toolbar>
+									<field name="id">
+										<String>Toolbar</String>
+									</field>
+									<field name="type">
+										<Integer>2</Integer>
+									</field>
+									<field name="largeIconPath">
+										<null/>
+									</field>
+									<field name="smallIconPath">
+										<null/>
+									</field>
+									<field name="toolbarEntriesDescriptorList">
+										<toolbarEntry-array/>
+									</field>
+								</toolbar>
+							</field>
+							<field name="additionalToolbarsDescriptors">
+								<null/>
+							</field>
+							<field name="contextualItems">
+								<contextProvider>
+									<field name="items">
+										<contextItem-array/>
+									</field>
+									<field name="removeItems">
+										<null/>
+									</field>
+								</contextProvider>
+							</field>
+							<field name="tableSupportClassName">
+								<null/>
+							</field>
+							<field name="tableCellSeparatorSupportClassName">
+								<null/>
+							</field>
+							<field name="tableColWidthSupportClassName">
+								<null/>
+							</field>
+							<field name="customReferencesResolver">
+								<null/>
+							</field>
+							<field name="editPropertiesHandler">
+								<null/>
+							</field>
+							<field name="authorExtensionStateListener">
+								<null/>
+							</field>
+							<field name="attributesRecognizer">
+								<null/>
+							</field>
+							<field name="authorActionEventHandler">
+								<null/>
+							</field>
+							<field name="authorImageDecorator">
+								<null/>
+							</field>
+						</authorExtension>
+					</field>
+					<field name="templatesLocations">
+						<String-array>
+							<String>${frameworkDir}/templates</String>
+						</String-array>
+					</field>
+					<field name="xmlCatalogs">
+						<String-array/>
+					</field>
+					<field name="description">
+						<String>Configuration files for staticSearch, a codebase to support a pure JSON search engine requiring no backend for any XHTML5 document collection.</String>
+					</field>
+					<field name="doctypeRules">
+						<documentTypeRule-array>
+							<documentTypeRule>
+								<field name="namespace">
+									<String>http://hcmc.uvic.ca/ns/staticSearch</String>
+								</field>
+								<field name="rootElem">
+									<String>config</String>
+								</field>
+								<field name="fileName">
+									<String>*</String>
+								</field>
+								<field name="publicID">
+									<String>*</String>
+								</field>
+								<field name="javaRuleClass">
+									<String></String>
+								</field>
+								<field name="attributeLocalName">
+									<String>*</String>
+								</field>
+								<field name="attributeNamespace">
+									<String>*</String>
+								</field>
+								<field name="attributeValue">
+									<String>*</String>
+								</field>
+							</documentTypeRule>
+						</documentTypeRule-array>
+					</field>
+					<field name="scenarios">
+						<scenario-array/>
+					</field>
+					<field name="validationScenarios">
+						<validationScenario-array>
+							<validationScenario>
+								<field name="pairs">
+									<list>
+										<validationUnit>
+											<field name="validationType">
+												<validationUnitType>
+													<field name="validationInputType">
+														<String>text/xml</String>
+													</field>
+												</validationUnitType>
+											</field>
+											<field name="url">
+												<String>${currentFileURL}</String>
+											</field>
+											<field name="validationEngine">
+												<validationEngine>
+													<field name="engineType">
+														<String>&lt;Default engine></String>
+													</field>
+													<field name="allowsAutomaticValidation">
+														<Boolean>true</Boolean>
+													</field>
+												</validationEngine>
+											</field>
+											<field name="allowAutomaticValidation">
+												<Boolean>true</Boolean>
+											</field>
+											<field name="extensions">
+												<null/>
+											</field>
+											<field name="validationSchema">
+												<null/>
+											</field>
+											<field name="validationAdvancedSettings">
+												<null/>
+											</field>
+										</validationUnit>
+										<validationUnit>
+											<field name="validationType">
+												<validationUnitType>
+													<field name="validationInputType">
+														<String>text/xml</String>
+													</field>
+												</validationUnitType>
+											</field>
+											<field name="url">
+												<String>${currentFileURL}</String>
+											</field>
+											<field name="validationEngine">
+												<validationEngine>
+													<field name="engineType">
+														<String>&lt;Default engine></String>
+													</field>
+													<field name="allowsAutomaticValidation">
+														<Boolean>true</Boolean>
+													</field>
+												</validationEngine>
+											</field>
+											<field name="allowAutomaticValidation">
+												<Boolean>true</Boolean>
+											</field>
+											<field name="extensions">
+												<null/>
+											</field>
+											<field name="validationSchema">
+												<validationUnitSchema>
+													<field name="dtdSchemaPublicID">
+														<null/>
+													</field>
+													<field name="schematronPhase">
+														<null/>
+													</field>
+													<field name="type">
+														<Integer>7</Integer>
+													</field>
+													<field name="uri">
+														<String>${framework}/schema/staticSearch.sch</String>
+													</field>
+												</validationUnitSchema>
+											</field>
+											<field name="validationAdvancedSettings">
+												<null/>
+											</field>
+										</validationUnit>
+									</list>
+								</field>
+								<field name="type">
+									<String>Validation_scenario</String>
+								</field>
+								<field name="name">
+									<String>staticSearch configuration</String>
+								</field>
+							</validationScenario>
+						</validationScenario-array>
+					</field>
+					<field name="defaultValidationScenarios">
+						<list>
+							<String>staticSearch configuration</String>
+						</list>
+					</field>
+					<field name="defaultTransformationScenarios">
+						<null/>
+					</field>
+					<field name="extensionsBundleClassName">
+						<null/>
+					</field>
+					<field name="useImposedInitialPage">
+						<Boolean>false</Boolean>
+					</field>
+					<field name="imposedInitialPage">
+						<String>Text</String>
+					</field>
+					<field name="elementLocatorExtension">
+						<null/>
+					</field>
+					<field name="schemaManagerFilterExtension">
+						<null/>
+					</field>
+					<field name="authorSWTDndExtension">
+						<null/>
+					</field>
+					<field name="textSWTDndExtension">
+						<null/>
+					</field>
+					<field name="authorSwingDndExtension">
+						<null/>
+					</field>
+					<field name="cssStylesFilterExtension">
+						<null/>
+					</field>
+					<field name="attributesValueEditor">
+						<null/>
+					</field>
+					<field name="priority">
+						<Integer>3</Integer>
+					</field>
+					<field name="xmlNodeCustomizerExtension">
+						<null/>
+					</field>
+					<field name="externalObjectInsertionHandler">
+						<null/>
+					</field>
+					<field name="customAttributeValueEditor">
+						<null/>
+					</field>
+					<field name="textModeExternalObjectInsertionHandler">
+						<null/>
+					</field>
+				</documentTypeDescriptor>
+			</documentTypeDescriptor-array>
+		</entry>
+	</serializableOrderedMap>
+</serialized>

--- a/templates/config_staticSearch.properties
+++ b/templates/config_staticSearch.properties
@@ -1,0 +1,3 @@
+type=general
+displayName=staticSearch configuration
+filenameSuffix=_staticSearch

--- a/templates/config_staticSearch.xml
+++ b/templates/config_staticSearch.xml
@@ -1,0 +1,11 @@
+<config xmlns="http://hcmc.uvic.ca/ns/staticSearch">
+ <params>
+<!--Parameters-->
+ </params>
+ <rules>
+<!--Rules-->
+ </rules>
+ <contexts>
+<!--Contexts-->
+ </contexts>
+</config>


### PR DESCRIPTION
Includes `build.xml` targets to generate an Oxygen add-on for the framework.

URLs of `add-on.xml` and the framework Zip file obviously should be changed to refer to 'projectEndings'.