### PR TITLE
Issue 268 filters

### DIFF
--- a/configTest.xml
+++ b/configTest.xml
@@ -50,7 +50,7 @@
             </label>
         </filter>
         <filter filterName="Random nonsense">
-            <label xmlns="http://www.w3.org/1999/xhtml">
+            <label xmlns="http://www.w3.org/1999/xhtml" lang="en">
                 <span style="font-variant: small-caps;">Random Piffle</span>
             </label>
         </filter>

--- a/configTest.xml
+++ b/configTest.xml
@@ -46,7 +46,7 @@
     <filters>
         <filter filterName="Worth reading">
             <label xmlns="http://www.w3.org/1999/xhtml">
-                <i>Really</i> worth reading!
+                <i>Really</i> worth reading
             </label>
         </filter>
     </filters>

--- a/configTest.xml
+++ b/configTest.xml
@@ -43,11 +43,11 @@
         <exclude match="meta[contains-token(@class,'excludedMeta')]" type="filter"/>
     </excludes>
     
-    <!--<filters>
+    <filters>
         <filter filterName="Worth reading">
             <label xmlns="http://www.w3.org/1999/xhtml">
                 <i>Really</i> worth reading!
             </label>
         </filter>
-    </filters>-->
+    </filters>
 </config>

--- a/configTest.xml
+++ b/configTest.xml
@@ -49,5 +49,11 @@
                 <i>Really</i> worth reading: 
             </label>
         </filter>
+        <filter filterName="Random nonsense">
+            <label xmlns="http://www.w3.org/1999/xhtml">
+                <span style="font-variant: small-caps;">Random Piffle</span>
+            </label>
+        </filter>
+            
     </filters>
 </config>

--- a/configTest.xml
+++ b/configTest.xml
@@ -46,7 +46,7 @@
     <filters>
         <filter filterName="Worth reading">
             <label xmlns="http://www.w3.org/1999/xhtml">
-                <i>Really</i> worth reading
+                <i>Really</i> worth reading: 
             </label>
         </filter>
     </filters>

--- a/configTest.xml
+++ b/configTest.xml
@@ -43,4 +43,11 @@
         <exclude match="meta[contains-token(@class,'excludedMeta')]" type="filter"/>
     </excludes>
     
+    <!--<filters>
+        <filter filterName="Worth reading">
+            <label xmlns="http://www.w3.org/1999/xhtml">
+                <i>Really</i> worth reading!
+            </label>
+        </filter>
+    </filters>-->
 </config>

--- a/docs/staticSearch.html
+++ b/docs/staticSearch.html
@@ -1,24 +1,14 @@
 <!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-   
    <head>
       <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-      
       <!--THIS FILE IS GENERATED FROM AN XML MASTER. DO NOT EDIT (5)-->
-      
       <title>Project Endings staticSearch Generator (Martin Holmes, Joey Takeda)</title>
-      
       <meta name="author" content="Martin Holmes and Joey Takeda"/>
-      
       <meta name="generator" content="Text Encoding Initiative Consortium XSLT stylesheets"/>
-      
       <meta name="DC.Title" content="Project Endings staticSearch GeneratorMartin Holmes, Joey Takeda."/>
-      
       <meta name="DC.Type" content="Text"/>
-      
       <meta name="DC.Format" content="text/html"/>
-      
       <link rel="stylesheet" href="documentation.css" type="text/css"/>
-      
       <link rel="stylesheet" media="print" type="text/css" href="https://www.tei-c.org/release/xml/tei/stylesheet/tei-print.css"/><script type="text/javascript"><!--
 var displayXML=0;
 states=new Array()
@@ -89,241 +79,142 @@ function showByMod() {
 }
 
         --></script></head>
-   
    <body class="simple" id="TOP"><!--TEI front-->
-      
       <div class="tei_front">
-         
          <div class="titlePage">
-            
             <div class="docTitle">
-               
                <div class="titlePart">Project Endings staticSearch Generator</div>
-               
                <div class="titlePart">Schema and guidelines for creating a staticSearch engine for your HTML5 site</div>
-               </div>
-            
-            <div class="docAuthor">Martin Holmes</div>
-            
-            <div class="docAuthor">Joey Takeda</div>
-            
-            <div class="docDate">2019-2023</div>
             </div>
-         
+            <div class="docAuthor">Martin Holmes</div>
+            <div class="docAuthor">Joey Takeda</div>
+            <div class="docDate">2019-2023</div>
+         </div>
          <p>This documentation provides instructions on how to use the Project Endings staticSearch
             Generator to provide a fully-functional search ‘engine’ to your website without any
             dependency on server-side code such as a database.</p>
-         
          <ul class="toc toc_body">
-            
             <li class="toc"><span class="headingNumber"> 1 </span><a class="toc toc_0" href="#whatDoesItDo" title="What does it do">What does it do?</a></li>
-            
             <li class="toc"><span class="headingNumber"> 2 </span><a class="toc toc_0" href="#whatDoesItNeed" title="What do I need in order to use this">What do I need in order to use this?</a></li>
-            
             <li class="toc"><span class="headingNumber"> 3 </span><a class="toc toc_0" href="#whyWouldIUseIt" title="Why would I use it">Why would I use it?</a></li>
-            
             <li class="toc"><span class="headingNumber"> 4 </span><a class="toc toc_0" href="#textSearchFeatures" title="Text search features">Text search features</a></li>
-            
             <li class="toc"><span class="headingNumber"> 5 </span><a class="toc toc_0" href="#searchFacetFeatures" title="Search facet features">Search facet features</a></li>
-            
             <li class="toc"><span class="headingNumber"> 6 </span><a class="toc toc_0" href="#searchPageCaptions" title="Search page captions">Search page captions</a></li>
-            
             <li class="toc"><span class="headingNumber"> 7 </span><a class="toc toc_0" href="#howDoIGetIt" title="How do I get it">How do I get it?</a></li>
-            
             <li class="toc"><span class="headingNumber"> 8 </span><a class="toc toc_0" href="#howDoIUseIt" title="How do I use it">How do I use it?</a><ul class="toc">
-                  
                   <li class="toc"><span class="headingNumber"> 8.1 </span><a class="toc toc_1" href="#filters" title="Configuring your site search filters">Configuring your site: search filters</a><ul class="toc">
-                        
                         <li class="toc"><span class="headingNumber">8.1.1 </span><a class="toc toc_2" href="#descFilters" title="Description filters">Description filters</a><ul class="toc">
-                              
                               <li class="toc"><span class="headingNumber">8.1.1.1 </span><a class="toc toc_3" href="#descFilterSorting" title="Sort order for description filters">Sort order for description filters</a></li>
-                              </ul>
-                           </li>
-                        
+                           </ul>
+                        </li>
                         <li class="toc"><span class="headingNumber">8.1.2 </span><a class="toc toc_2" href="#dateFilters" title="Date filters">Date filters</a></li>
-                        
                         <li class="toc"><span class="headingNumber">8.1.3 </span><a class="toc toc_2" href="#numFilters" title="Number filters">Number filters</a></li>
-                        
                         <li class="toc"><span class="headingNumber">8.1.4 </span><a class="toc toc_2" href="#boolFilters" title="Boolean filters">Boolean filters</a></li>
-                        
                         <li class="toc"><span class="headingNumber">8.1.5 </span><a class="toc toc_2" href="#featFilters" title="Feature filters">Feature filters</a></li>
-                        </ul>
-                     </li>
-                  
+                     </ul>
+                  </li>
                   <li class="toc"><span class="headingNumber"> 8.2 </span><a class="toc toc_1" href="#configuringDocTitles" title="Configuring your site document titles">Configuring your site: document titles</a></li>
-                  
                   <li class="toc"><span class="headingNumber"> 8.3 </span><a class="toc toc_1" href="#configuringDocSortKey" title="Configuring your site document sort keys">Configuring your site: document sort keys</a></li>
-                  
                   <li class="toc"><span class="headingNumber"> 8.4 </span><a class="toc toc_1" href="#configuringDocThumbnails" title="Configuring your site document thumbnails">Configuring your site: document thumbnails</a></li>
-                  
                   <li class="toc"><span class="headingNumber"> 8.5 </span><a class="toc toc_1" href="#creatingConfigFile" title="Creating a configuration file">Creating a configuration file</a><ul class="toc">
-                        
                         <li class="toc"><span class="headingNumber">8.5.1 </span><a class="toc toc_2" href="#rootConfigElement" title="The config element">The config element</a></li>
-                        
                         <li class="toc"><span class="headingNumber">8.5.2 </span><a class="toc toc_2" href="#specifyingParameters" title="Specifying parameters">Specifying parameters</a><ul class="toc">
-                              
                               <li class="toc"><span class="headingNumber">8.5.2.1 </span><a class="toc toc_3" href="#paramsRequired" title="Required parameters">Required parameters</a></li>
-                              
                               <li class="toc"><span class="headingNumber">8.5.2.2 </span><a class="toc toc_3" href="#paramsOptional" title="Optional parameters">Optional parameters</a></li>
-                              </ul>
-                           </li>
-                        
+                           </ul>
+                        </li>
                         <li class="toc"><span class="headingNumber">8.5.3 </span><a class="toc toc_2" href="#specifyingRules" title="Specifying rules (optional)">Specifying rules (optional)</a></li>
-                        
                         <li class="toc"><span class="headingNumber">8.5.4 </span><a class="toc toc_2" href="#specifyingContexts" title="Specifying contexts (optional)">Specifying contexts (optional)</a></li>
-                        
                         <li class="toc"><span class="headingNumber">8.5.5 </span><a class="toc toc_2" href="#searchOnlyIn" title="Specifying searchable contexts (search only in)">Specifying searchable contexts (search only in)</a></li>
-                        
                         <li class="toc"><span class="headingNumber">8.5.6 </span><a class="toc toc_2" href="#specifyingExclusions" title="Specifying exclusions (optional)">Specifying exclusions (optional)</a></li>
-                        </ul>
-                     </li>
-                  
+                     </ul>
+                  </li>
                   <li class="toc"><span class="headingNumber"> 8.6 </span><a class="toc toc_1" href="#searchPage" title="Creating a search page">Creating a search page</a></li>
-                  
                   <li class="toc"><span class="headingNumber"> 8.7 </span><a class="toc toc_1" href="#searchBuildProcess" title="Running the search build process">Running the search build process</a></li>
-                  
                   <li class="toc"><span class="headingNumber"> 8.8 </span><a class="toc toc_1" href="#callingStaticSearchFromAnt" title="Running staticSearch from Ant">Running staticSearch from Ant</a></li>
-                  
                   <li class="toc"><span class="headingNumber"> 8.9 </span><a class="toc toc_1" href="#theStaticSearchReport" title="Generated report">Generated report</a></li>
-                  
                   <li class="toc"><span class="headingNumber"> 8.10 </span><a class="toc toc_1" href="#advancedFeatures" title="Advanced features">Advanced features</a><ul class="toc">
-                        
                         <li class="toc"><span class="headingNumber">8.10.1 </span><a class="toc toc_2" href="#customAttributes" title="Custom attributes">Custom attributes</a></li>
-                        
                         <li class="toc"><span class="headingNumber">8.10.2 </span><a class="toc toc_2" href="#highlightTargetPage" title="Highlighting search hits on target pages">Highlighting search hits on target pages</a></li>
-                        </ul>
-                     </li>
-                  </ul>
-               </li>
-            
-            <li class="toc"><span class="headingNumber"> 9 </span><a class="toc toc_0" href="#howDoesItWork" title="How does it work">How does it work?</a><ul class="toc">
-                  
-                  <li class="toc"><span class="headingNumber"> 9.1 </span><a class="toc toc_1" href="#buildingTheIndex" title="Building the index">Building the index</a></li>
-                  
-                  <li class="toc"><span class="headingNumber"> 9.2 </span><a class="toc toc_1" href="#theSearchPage" title="The search page">The search page</a></li>
-                  
-                  <li class="toc"><span class="headingNumber"> 9.3 </span><a class="toc toc_1" href="#jsCompilation" title="JavaScript compilation">JavaScript compilation</a></li>
-                  
-                  <li class="toc"><span class="headingNumber"> 9.4 </span><a class="toc toc_1" href="#jsInitialization" title="The JavaScript Initializer file">The JavaScript Initializer file</a></li>
-                  </ul>
-               </li>
-            
-            <li class="toc"><span class="headingNumber">10 </span><a class="toc toc_0" href="#howDoI" title="How do I...">How do I...</a></li>
-            
-            <li class="toc"><span class="headingNumber">11 </span><a class="toc toc_0" href="#newSinceVersion1" title="Whats new since version 1.0">What's new since version 1.0?</a><ul class="toc">
-                  
-                  <li class="toc"><span class="headingNumber">11.1 </span><a class="toc toc_1" href="#newIn2.0" title="Changes in version 2.0">Changes in version 2.0</a></li>
-                  
-                  <li class="toc"><span class="headingNumber">11.2 </span><a class="toc toc_1" href="#newIn1.4.3" title="Changes in version 1.4.3">Changes in version 1.4.3</a></li>
-                  
-                  <li class="toc"><span class="headingNumber">11.3 </span><a class="toc toc_1" href="#newIn1.4.2" title="Changes in version 1.4.2">Changes in version 1.4.2</a></li>
-                  
-                  <li class="toc"><span class="headingNumber">11.4 </span><a class="toc toc_1" href="#newIn1.4.1" title="Changes in version 1.4.1">Changes in version 1.4.1</a></li>
-                  
-                  <li class="toc"><span class="headingNumber">11.5 </span><a class="toc toc_1" href="#newIn1.4" title="Changes in version 1.4">Changes in version 1.4</a></li>
-                  
-                  <li class="toc"><span class="headingNumber">11.6 </span><a class="toc toc_1" href="#newIn1.3" title="Changes in version 1.3">Changes in version 1.3</a></li>
-                  
-                  <li class="toc"><span class="headingNumber">11.7 </span><a class="toc toc_1" href="#newIn1.1" title="Changes in version 1.1">Changes in version 1.1</a></li>
-                  </ul>
-               </li>
-            
-            <li class="toc"><span class="headingNumber">12 </span><a class="toc toc_0" href="#projectsUsingSS" title="Projects using staticSearch">Projects using staticSearch</a></li>
-            </ul>
-         
-         <ul class="toc toc_back">
-            
-            <li class="toc"><span class="headingNumber">Appendix A </span><a class="toc toc_0" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a><ul class="toc">
-                  
-                  <li class="toc"><span class="headingNumber">Appendix A.1 </span><a class="toc toc_1" href="#index.xml-back.1_div.1_div.1">Elements</a><ul class="toc">
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.1 </span><a class="toc toc_2" href="#TEI.config" title="&lt;config&gt;">&lt;config&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.2 </span><a class="toc toc_2" href="#TEI.context" title="&lt;context&gt;">&lt;context&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.3 </span><a class="toc toc_2" href="#TEI.contexts" title="&lt;contexts&gt;">&lt;contexts&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.4 </span><a class="toc toc_2" href="#TEI.createContexts" title="&lt;createContexts&gt;">&lt;createContexts&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.5 </span><a class="toc toc_2" href="#TEI.dictionaryFile" title="&lt;dictionaryFile&gt;">&lt;dictionaryFile&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.6 </span><a class="toc toc_2" href="#TEI.exclude" title="&lt;exclude&gt;">&lt;exclude&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.7 </span><a class="toc toc_2" href="#TEI.excludes" title="&lt;excludes&gt;">&lt;excludes&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.8 </span><a class="toc toc_2" href="#TEI.kwicTruncateString" title="&lt;kwicTruncateString&gt;">&lt;kwicTruncateString&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.9 </span><a class="toc toc_2" href="#TEI.linkToFragmentId" title="&lt;linkToFragmentId&gt;">&lt;linkToFragmentId&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.10 </span><a class="toc toc_2" href="#TEI.maxKwicsToHarvest" title="&lt;maxKwicsToHarvest&gt;">&lt;maxKwicsToHarvest&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.11 </span><a class="toc toc_2" href="#TEI.maxKwicsToShow" title="&lt;maxKwicsToShow&gt;">&lt;maxKwicsToShow&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.12 </span><a class="toc toc_2" href="#TEI.minWordLength" title="&lt;minWordLength&gt;">&lt;minWordLength&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.13 </span><a class="toc toc_2" href="#TEI.outputFolder" title="&lt;outputFolder&gt;">&lt;outputFolder&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.14 </span><a class="toc toc_2" href="#TEI.params" title="&lt;params&gt;">&lt;params&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.15 </span><a class="toc toc_2" href="#TEI.phrasalSearch" title="&lt;phrasalSearch&gt;">&lt;phrasalSearch&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.16 </span><a class="toc toc_2" href="#TEI.recurse" title="&lt;recurse&gt;">&lt;recurse&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.17 </span><a class="toc toc_2" href="#TEI.resultsLimit" title="&lt;resultsLimit&gt;">&lt;resultsLimit&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.18 </span><a class="toc toc_2" href="#TEI.resultsPerPage" title="&lt;resultsPerPage&gt;">&lt;resultsPerPage&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.19 </span><a class="toc toc_2" href="#TEI.rule" title="&lt;rule&gt;">&lt;rule&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.20 </span><a class="toc toc_2" href="#TEI.rules" title="&lt;rules&gt;">&lt;rules&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.21 </span><a class="toc toc_2" href="#TEI.scoringAlgorithm" title="&lt;scoringAlgorithm&gt;">&lt;scoringAlgorithm&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.22 </span><a class="toc toc_2" href="#TEI.searchFile" title="&lt;searchFile&gt;">&lt;searchFile&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.23 </span><a class="toc toc_2" href="#TEI.stemmerFolder" title="&lt;stemmerFolder&gt;">&lt;stemmerFolder&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.24 </span><a class="toc toc_2" href="#TEI.stopwordsFile" title="&lt;stopwordsFile&gt;">&lt;stopwordsFile&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.25 </span><a class="toc toc_2" href="#TEI.totalKwicLength" title="&lt;totalKwicLength&gt;">&lt;totalKwicLength&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.26 </span><a class="toc toc_2" href="#TEI.versionFile" title="&lt;versionFile&gt;">&lt;versionFile&gt;</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.1.27 </span><a class="toc toc_2" href="#TEI.wildcardSearch" title="&lt;wildcardSearch&gt;">&lt;wildcardSearch&gt;</a></li>
-                        </ul>
-                     </li>
-                  
-                  <li class="toc"><span class="headingNumber">Appendix A.2 </span><a class="toc toc_1" href="#index.xml-back.1_div.1_div.2">Attribute classes</a><ul class="toc">
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.2.1 </span><a class="toc toc_2" href="#TEI.att.labelled" title="att.labelled">att.labelled</a></li>
-                        
-                        <li class="toc"><span class="headingNumber">Appendix A.2.2 </span><a class="toc toc_2" href="#TEI.att.match" title="att.match">att.match</a></li>
-                        </ul>
-                     </li>
-                  </ul>
-               </li>
-            </ul>
-         </div>
-      <!--TEI body-->
-      
-      <div class="tei_body">
-         
-         <h1>Project Endings staticSearch Generator</h1>
-         
-         <section class="teidiv0" id="whatDoesItDo">
-            
-            <header>
-               
-               <h2><span class="headingNumber">1 </span><span class="head">What does it do?</span></h2>
-               </header>
-            
-            <ul>
-               
-               <li class="item">Level: Basic</li>
-               
-               <li class="item">Last Updated: <span class="date">14 October 2020</span></li>
+                     </ul>
+                  </li>
                </ul>
-            
+            </li>
+            <li class="toc"><span class="headingNumber"> 9 </span><a class="toc toc_0" href="#howDoesItWork" title="How does it work">How does it work?</a><ul class="toc">
+                  <li class="toc"><span class="headingNumber"> 9.1 </span><a class="toc toc_1" href="#buildingTheIndex" title="Building the index">Building the index</a></li>
+                  <li class="toc"><span class="headingNumber"> 9.2 </span><a class="toc toc_1" href="#theSearchPage" title="The search page">The search page</a></li>
+                  <li class="toc"><span class="headingNumber"> 9.3 </span><a class="toc toc_1" href="#jsCompilation" title="JavaScript compilation">JavaScript compilation</a></li>
+                  <li class="toc"><span class="headingNumber"> 9.4 </span><a class="toc toc_1" href="#jsInitialization" title="The JavaScript Initializer file">The JavaScript Initializer file</a></li>
+               </ul>
+            </li>
+            <li class="toc"><span class="headingNumber">10 </span><a class="toc toc_0" href="#howDoI" title="How do I...">How do I...</a></li>
+            <li class="toc"><span class="headingNumber">11 </span><a class="toc toc_0" href="#newSinceVersion1" title="Whats new since version 1.0">What's new since version 1.0?</a><ul class="toc">
+                  <li class="toc"><span class="headingNumber">11.1 </span><a class="toc toc_1" href="#newIn2.0" title="Changes in version 2.0">Changes in version 2.0</a></li>
+                  <li class="toc"><span class="headingNumber">11.2 </span><a class="toc toc_1" href="#newIn1.4.3" title="Changes in version 1.4.3">Changes in version 1.4.3</a></li>
+                  <li class="toc"><span class="headingNumber">11.3 </span><a class="toc toc_1" href="#newIn1.4.2" title="Changes in version 1.4.2">Changes in version 1.4.2</a></li>
+                  <li class="toc"><span class="headingNumber">11.4 </span><a class="toc toc_1" href="#newIn1.4.1" title="Changes in version 1.4.1">Changes in version 1.4.1</a></li>
+                  <li class="toc"><span class="headingNumber">11.5 </span><a class="toc toc_1" href="#newIn1.4" title="Changes in version 1.4">Changes in version 1.4</a></li>
+                  <li class="toc"><span class="headingNumber">11.6 </span><a class="toc toc_1" href="#newIn1.3" title="Changes in version 1.3">Changes in version 1.3</a></li>
+                  <li class="toc"><span class="headingNumber">11.7 </span><a class="toc toc_1" href="#newIn1.1" title="Changes in version 1.1">Changes in version 1.1</a></li>
+               </ul>
+            </li>
+            <li class="toc"><span class="headingNumber">12 </span><a class="toc toc_0" href="#projectsUsingSS" title="Projects using staticSearch">Projects using staticSearch</a></li>
+         </ul>
+         <ul class="toc toc_back">
+            <li class="toc"><span class="headingNumber">Appendix A </span><a class="toc toc_0" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a><ul class="toc">
+                  <li class="toc"><span class="headingNumber">Appendix A.1 </span><a class="toc toc_1" href="#index.xml-back.1_div.1_div.1">Elements</a><ul class="toc">
+                        <li class="toc"><span class="headingNumber">Appendix A.1.1 </span><a class="toc toc_2" href="#TEI.config" title="&lt;config&gt;">&lt;config&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.2 </span><a class="toc toc_2" href="#TEI.context" title="&lt;context&gt;">&lt;context&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.3 </span><a class="toc toc_2" href="#TEI.contexts" title="&lt;contexts&gt;">&lt;contexts&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.4 </span><a class="toc toc_2" href="#TEI.createContexts" title="&lt;createContexts&gt;">&lt;createContexts&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.5 </span><a class="toc toc_2" href="#TEI.dictionaryFile" title="&lt;dictionaryFile&gt;">&lt;dictionaryFile&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.6 </span><a class="toc toc_2" href="#TEI.exclude" title="&lt;exclude&gt;">&lt;exclude&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.7 </span><a class="toc toc_2" href="#TEI.excludes" title="&lt;excludes&gt;">&lt;excludes&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.8 </span><a class="toc toc_2" href="#TEI.filter" title="&lt;filter&gt;">&lt;filter&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.9 </span><a class="toc toc_2" href="#TEI.filters" title="&lt;filters&gt;">&lt;filters&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.10 </span><a class="toc toc_2" href="#TEI.kwicTruncateString" title="&lt;kwicTruncateString&gt;">&lt;kwicTruncateString&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.11 </span><a class="toc toc_2" href="#TEI.xh_label" title="&lt;label&gt;">&lt;label&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.12 </span><a class="toc toc_2" href="#TEI.linkToFragmentId" title="&lt;linkToFragmentId&gt;">&lt;linkToFragmentId&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.13 </span><a class="toc toc_2" href="#TEI.maxKwicsToHarvest" title="&lt;maxKwicsToHarvest&gt;">&lt;maxKwicsToHarvest&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.14 </span><a class="toc toc_2" href="#TEI.maxKwicsToShow" title="&lt;maxKwicsToShow&gt;">&lt;maxKwicsToShow&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.15 </span><a class="toc toc_2" href="#TEI.minWordLength" title="&lt;minWordLength&gt;">&lt;minWordLength&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.16 </span><a class="toc toc_2" href="#TEI.outputFolder" title="&lt;outputFolder&gt;">&lt;outputFolder&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.17 </span><a class="toc toc_2" href="#TEI.params" title="&lt;params&gt;">&lt;params&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.18 </span><a class="toc toc_2" href="#TEI.phrasalSearch" title="&lt;phrasalSearch&gt;">&lt;phrasalSearch&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.19 </span><a class="toc toc_2" href="#TEI.recurse" title="&lt;recurse&gt;">&lt;recurse&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.20 </span><a class="toc toc_2" href="#TEI.resultsLimit" title="&lt;resultsLimit&gt;">&lt;resultsLimit&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.21 </span><a class="toc toc_2" href="#TEI.resultsPerPage" title="&lt;resultsPerPage&gt;">&lt;resultsPerPage&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.22 </span><a class="toc toc_2" href="#TEI.rule" title="&lt;rule&gt;">&lt;rule&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.23 </span><a class="toc toc_2" href="#TEI.rules" title="&lt;rules&gt;">&lt;rules&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.24 </span><a class="toc toc_2" href="#TEI.scoringAlgorithm" title="&lt;scoringAlgorithm&gt;">&lt;scoringAlgorithm&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.25 </span><a class="toc toc_2" href="#TEI.searchFile" title="&lt;searchFile&gt;">&lt;searchFile&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.26 </span><a class="toc toc_2" href="#TEI.stemmerFolder" title="&lt;stemmerFolder&gt;">&lt;stemmerFolder&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.27 </span><a class="toc toc_2" href="#TEI.stopwordsFile" title="&lt;stopwordsFile&gt;">&lt;stopwordsFile&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.28 </span><a class="toc toc_2" href="#TEI.totalKwicLength" title="&lt;totalKwicLength&gt;">&lt;totalKwicLength&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.29 </span><a class="toc toc_2" href="#TEI.versionFile" title="&lt;versionFile&gt;">&lt;versionFile&gt;</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.1.30 </span><a class="toc toc_2" href="#TEI.wildcardSearch" title="&lt;wildcardSearch&gt;">&lt;wildcardSearch&gt;</a></li>
+                     </ul>
+                  </li>
+                  <li class="toc"><span class="headingNumber">Appendix A.2 </span><a class="toc toc_1" href="#index.xml-back.1_div.1_div.2">Attribute classes</a><ul class="toc">
+                        <li class="toc"><span class="headingNumber">Appendix A.2.1 </span><a class="toc toc_2" href="#TEI.att.labelled" title="att.labelled">att.labelled</a></li>
+                        <li class="toc"><span class="headingNumber">Appendix A.2.2 </span><a class="toc toc_2" href="#TEI.att.match" title="att.match">att.match</a></li>
+                     </ul>
+                  </li>
+               </ul>
+            </li>
+         </ul>
+      </div>
+      <!--TEI body-->
+      <div class="tei_body">
+         <h1>Project Endings staticSearch Generator</h1>
+         <section class="teidiv0" id="whatDoesItDo">
+            <header>
+               <h2><span class="headingNumber">1 </span><span class="head">What does it do?</span></h2>
+            </header>
+            <ul>
+               <li class="item">Level: Basic</li>
+               <li class="item">Last Updated: <span class="date">14 October 2020</span></li>
+            </ul>
             <p>The generator tool processes your site to create an index of all the words appearing
                in the site, stemmed (if desired) using a stemmer, and stores the index in the form
                of a large number of small JSON files. It also creates JSON files for other search
@@ -331,157 +222,107 @@ function showByMod() {
                by type, by date range, and so on. Then it creates a search page for your site, which
                processes user search terms and retrieves the required JSON files to provide search
                results.</p>
-            
             <p>You can see several examples of sites and projects which use staticSearch in <a class="link_ref" href="#projectsUsingSS" title="Projects using staticSearch">Projects using staticSearch</a>.</p>
-            </section>
-         
+         </section>
          <section class="teidiv0" id="whatDoesItNeed">
-            
             <header>
-               
                <h2><span class="headingNumber">2 </span><span class="head">What do I need in order to use this?</span></h2>
-               </header>
-            
+            </header>
             <ul>
-               
                <li class="item">Level: Basic</li>
-               
                <li class="item">Last Updated: <span class="date">7 March 2023</span></li>
-               </ul>
-            
+            </ul>
             <p>In order to build a static search index on your document collection, you will need:</p>
-            
             <ul>
-               
                <li class="item">A collection of <a class="link_ref" href="https://www.lesliesikos.com/xhtml5-the-zenith-of-markup-languages/">XHTML5 documents</a> (HTML documents which are in the XHTML namespace and are well-formed).</li>
-               
                <li class="item">A computer running a recent version of Linux, Mac OSX, or Windows</li>
-               
                <li class="item">Java, <a class="link_ref" href="https://ant.apache.org/">Apache Ant</a>, and <a class="link_ref" href="https://ant-contrib.sourceforge.net/">ant-contrib</a> installed on the system.</li>
-               </ul>
-            
+            </ul>
             <p>Once you have run the indexing process on your document collection, you can place
                the results on any web server and the search will work with any modern browser. The
                requirements above are only for building the search index, which you only need to
                do once (until your documents change).</p>
-            </section>
-         
+         </section>
          <section class="teidiv0" id="whyWouldIUseIt">
-            
             <header>
-               
                <h2><span class="headingNumber">3 </span><span class="head">Why would I use it?</span></h2>
-               </header>
-            
+            </header>
             <ul>
-               
                <li class="item">Level: Basic</li>
-               
                <li class="item">Last Updated: <span class="date">8 May 2020</span></li>
-               </ul>
-            
+            </ul>
             <p>Digital Humanities projects such as digital editions of historical and literary texts
                are typically the work of teams of people collaborating over many years, and the fruit
                of their labours deserves to have a significant shelf-life, if possible comparable
                with that of a traditional print publication. However, digital longevity of DH projects
                is sadly short, and many disappear or cease to function within a few years of their
                creation, because of their dependency on transient tools and technologies.</p>
-            
             <p>However, static websites (websites which consist entirely of HTML, CSS and JavaScript,
                without any dependency on back-end server systems such as databases or PHP processing)
                are far more resilient in the long term than sites which use more server-side technology,
                and are also much easier to archive and replicate (see Holmes and Takeda (2019), <a class="link_ref" href="https://zenodo.org/record/3449197">The Prefabricated Website: Who needs a server anyway?</a>). For this reason, the <a class="link_ref" href="https://projectendings.github.io/">Project Endings</a> team have been developing and publicizing strategies for moving digital projects
                to an all-static publication model. The most problematic component in the all-static
                approach is search.</p>
-            
             <p>Most digital publications take one of two approaches to search: either they have their
                own back-end database search engine (perhaps Solr or an XML database), or they rely
                on commercial services such as Google (which may be free, but are still beyond the
                control of the project team). DH projects need sophisticated options for searching,
                but typically this requires the use of technologies that may become obsolete or unsupported,
                or services which may change their terms of use or become unavailable.</p>
-            
             <p>staticSearch solves this problem. It provides the capability to build a sophisticated
                faceted search engine into your website without the need for any back-end services
                at all (except of course for a web server, which you need anyway).</p>
-            </section>
-         
+         </section>
          <section class="teidiv0" id="textSearchFeatures">
-            
             <header>
-               
                <h2><span class="headingNumber">4 </span><span class="head">Text search features</span></h2>
-               </header>
-            
+            </header>
             <ul>
-               
                <li class="item">Level: Intermediate</li>
-               
                <li class="item">Last Updated: <span class="date">26 January 2021</span></li>
-               </ul>
-            
+            </ul>
             <p>The Generator supports the following features:</p>
-            
             <ul>
-               
                <li class="item">Stemming of terms (so searching for <span class="q">‘wait’</span> will also retrieve <span class="q">‘waiting’</span>, <span class="q">‘waits’</span>, <span class="q">‘waited’</span> etc.). Our default stemmer is the English Porter 2 stemmer, but there is also a French
                   stemmer, as well as an ‘identity’ stemmer (which makes no changes) and a diacritic-stripping
                   stemmer. If you have documents in another language, you can create and plug in your
                   own stemmer.</li>
-               
                <li class="item">Boolean search operators. Adding <code>+</code> (plus) before a word means that search results <em>must contain</em> that word, and adding a <code>-</code> (minus) means that results <em>must not contain</em> that word. Words without plus or minus are treated as <em>may contain</em>, contributing to the score of any retrieved document.</li>
-               
                <li class="item">Phrasal searches. Any quoted phrase will be searched as-is, and when quoted phrases
                   are included in a search, any hit document must contain at least one of them. Note
                   that phrasal search support requires a specific setting in your configuration file,
                   because it increases the size of the index.</li>
-               
                <li class="item">Keyword-in-context search results. This is also configurable, since including contexts
                   increases the size of the index.</li>
-               
                <li class="item">Wildcard searches, using the asterisk (*), question mark (?) and character classes
                   ([ab]). So you can search for <code>lo[uv]e?</code> to find <span class="q">‘loved’</span>, <span class="q">‘loued’</span>, <span class="q">‘loves’</span>, <span class="q">‘louer’</span>, etc. If you don't have a stemmer for the language of your document collection, this
                   feature is a good alternative (although it can be combined with a stemmer as well
                   for greater flexibility).</li>
-               
                <li class="item">Search filtering using any metadata you like, allowing users to limit their search
                   to specific document types, date ranges, or other features.</li>
-               </ul>
-            </section>
-         
+            </ul>
+         </section>
          <section class="teidiv0" id="searchFacetFeatures">
-            
             <header>
-               
                <h2><span class="headingNumber">5 </span><span class="head">Search facet features</span></h2>
-               </header>
-            
+            </header>
             <ul>
-               
                <li class="item">Level: Basic</li>
-               
                <li class="item">Last Updated: <span class="date">12 May 2021</span></li>
-               </ul>
-            
+            </ul>
             <p>The Generator supports the following search facets or filters:</p>
-            
             <ul>
-               
                <li class="item"><span class="term">Descriptors</span>. You might for example classify your documents as poems, short stories and novels;
                   the user can then choose to search in only poems, or poems and short stories.</li>
-               
                <li class="item"><span class="term">Date ranges</span>. You might assign each document a date (or a date range) for its first publication
                   and another for its last publication; then users could search for documents first
                   published in a certain date range and last published before another date.</li>
-               
                <li class="item"><span class="term">Number ranges</span>. Similar to date ranges, you can assign a number to each document and then filter
                   the search on a subrange of those numbers. For example, a collection of poems might
                   be filtered on the number of stanzas, so users could find all two-stanza poems or
                   all poems with three or more stanzas.</li>
-               
                <li class="item"><span class="term">Booleans</span> (true/false values). You might for instance specify that some poems are illustrated
                   while others are not. The user could then limit their search only to illustrated poems.</li>
-               
                <li class="item"><span class="term">Features</span>. Features are similar to Descriptors, but are intended for cases where there are
                   so many possibly items that having a long list of checkboxes on the page is not practical,
                   so instead, a typeahead control is provided, allowing the user to type some characters
@@ -490,180 +331,120 @@ function showByMod() {
                   might mention twenty of them. The searcher can type a few letters of a person's name
                   to see a list of suggestions, and then add checkboxes for any matching people; those
                   checkboxes will then function like Descriptor checkboxes.</li>
-               </ul>
-            </section>
-         
+            </ul>
+         </section>
          <section class="teidiv0" id="searchPageCaptions">
-            
             <header>
-               
                <h2><span class="headingNumber">6 </span><span class="head">Search page captions</span></h2>
-               </header>
-            
+            </header>
             <ul>
-               
                <li class="item">Level: Intermediate</li>
-               
                <li class="item">Last Updated: <span class="date">24 January 2021</span></li>
-               </ul>
-            
+            </ul>
             <p>Various captions (<span class="q">‘Searching...’</span>, <span class="q">‘Documents found’</span>, <span class="q">‘Score’</span> and so on) are shown during operations in the search page. These captions are currently
                configured in the JavaScript file <span class="ident">ssSearch.js</span> in the form of a JavaScript array which has both English and French captions. The
                caption language is selected based on the <span class="att">lang</span> attribute on the root <span class="gi">&lt;html&gt;</span> element of the search page; if there are no captions configured for the language
                in the <span class="att">lang</span> attribute, the default English captions are used.</p>
-            
             <p>If your search page is in a language other than English and French, please contribute
                to the project by providing captions in that language so that we can increase the
                number of languages supported by the project. When the number of available language
                caption sets becomes significant, we will abstract them from the core JavaScript library
                and store them in a separate location, inserting them into the page at build time
                instead.</p>
-            </section>
-         
+         </section>
          <section class="teidiv0" id="howDoIGetIt">
-            
             <header>
-               
                <h2><span class="headingNumber">7 </span><span class="head">How do I get it?</span></h2>
-               </header>
-            
+            </header>
             <ul>
-               
                <li class="item">Level: Basic</li>
-               
                <li class="item">Last Updated: <span class="date">13 January 2020</span></li>
-               </ul>
-            
+            </ul>
             <p>There are two ways to get the staticSearch code. The first is to download a release
                package from the <a class="link_ref" href="https://github.com/projectEndings/staticSearch/releases/">project release page</a>; we recommend that you get the latest version. You can download a zip file and unzip
                it to create a folder containing the code.</p>
-            
             <p>The second way to get the codebase is to clone it from the <a class="link_ref" href="https://github.com/projectEndings/staticSearch">GitHub repository</a>. If you're doing this, you can clone either the current master branch, the last release
                tag, or the dev branch. If you clone the dev branch, bear in mind that you're working
                with development code and things may break.</p>
-            </section>
-         
+         </section>
          <section class="teidiv0" id="howDoIUseIt">
-            
             <header>
-               
                <h2><span class="headingNumber">8 </span><span class="head">How do I use it?</span></h2>
-               </header>
-            
+            </header>
             <ul>
-               
                <li class="item">Level: Intermediate</li>
-               
                <li class="item">Last Updated: <span class="date">26 February 2021</span></li>
-               </ul>
-            
+            </ul>
             <p>First, you will have to make sure your site pages are correctly configured so that
                the Generator can parse them. Then, you will have to create a configuration file specifying
                what options you want to use. Then you run the generator, and the search functionality
                should be added to your site.</p>
-            
             <p>The generator is expecting to parse <em>well-formed XHTML5 web pages</em>. That means web pages which are well-formed XML, using the XHTML namespace. If your
                site is just raggedy tag-soup, then you can't use this tool. You can tidy up your
                HTML using <a class="link_ref" href="http://www.html-tidy.org/">HTML Tidy</a>.</p>
-            
             <div class="teidiv1" id="filters">
-               
                <h3><span class="headingNumber">8.1 </span><span class="head">Configuring your site: search filters</span></h3>
-               
                <p>Next, you will need to decide whether you want search filters or not. If you want
                   to allow your users to search (for example) only in poems, or only in articles, or
                   only in blog posts, or any combination of these document types, you will need to add
                   <span class="gi">&lt;meta&gt;</span> tags to the heads of your documents to specify what these filters are. <span class="titlem">staticSearch</span> supports four filter types.</p>
-               
                <div class="teidiv2" id="descFilters">
-                  
                   <h3><span class="headingNumber">8.1.1 </span><span class="head">Description filters</span></h3>
-                  
                   <div class="p">The description (desc) filter is a word or phrase describing or associated with the
                      document. Here is a simple example: 
-                     
                      <div id="index.xml-egXML-d38e250" class="pre egXML_valid"><span class="element">&lt;meta <span class="attribute">name</span>="<span class="attributevalue">Document type</span>"<br/> <span class="attribute">class</span>="<span class="attributevalue">staticSearch_desc</span>" <span class="attribute">content</span>="<span class="attributevalue">Poems</span>"/&gt;</span></div> This specifies that there is to be a descriptive search filter called <span class="q">‘Document type’</span>, and one of the types is <span class="q">‘Poems’</span>; the document containing this <span class="gi">&lt;meta&gt;</span> tag is one of the Poems. Another type might be: 
-                     
                      <div id="index.xml-egXML-d38e259" class="pre egXML_valid"><span class="element">&lt;meta <span class="attribute">name</span>="<span class="attributevalue">Document type</span>"<br/> <span class="attribute">class</span>="<span class="attributevalue">staticSearch_desc</span>" <span class="attribute">content</span>="<span class="attributevalue">Short stories</span>"/&gt;</span></div> If the Generator finds such meta tags when it is indexing, it will create a set of
                      filter controls on the search page, enabling the user to constrain the search to a
                      specific set of filter settings.</div>
-                  
                   <div class="teidiv3" id="descFilterSorting">
-                     
                      <h4><span class="headingNumber">8.1.1.1 </span><span class="head">Sort order for description filters</span></h4>
-                     
                      <div class="p">Description filter labels may be plain text such as <span class="q">‘Short stories’</span> or <span class="q">‘Poems’</span>, but they may also be more obscure labels relating to document categories in indexing
                         systems or archival series identifiers. When the search page is generated, these labels
                         are turned into a series of labelled checkboxes, sorted in alphabetical order. However,
                         the strict alphabetical order of items may not be exactly what you want; you may want
                         to sort <span class="q">‘305 2’</span> before <span class="q">‘305 10’</span> for example. To deal with cases like this, in addition to the <span class="att">content</span> attribute, you can also supply a custom <span class="att">data-ssfiltersortkey</span> attribute, providing a sort key for each label. Here is are a couple of examples:
                         
-                        
                         <div id="index.xml-egXML-d38e281" class="pre egXML_valid"><span class="element">&lt;meta <span class="attribute">name</span>="<span class="attributevalue">Archival series</span>"<br/> <span class="attribute">class</span>="<span class="attributevalue">staticSearch_desc</span>" <span class="attribute">data-ssfiltersortkey</span>="<span class="attributevalue">305_02</span>"<br/> <span class="attribute">content</span>="<span class="attributevalue">305 2</span>"/&gt;</span><br/><span class="element">&lt;meta <span class="attribute">name</span>="<span class="attributevalue">Archival series</span>"<br/> <span class="attribute">class</span>="<span class="attributevalue">staticSearch_desc</span>" <span class="attribute">data-ssfiltersortkey</span>="<span class="attributevalue">305_10</span>"<br/> <span class="attribute">content</span>="<span class="attributevalue">305 10</span>"/&gt;</span></div> In this case, the first item will sort in the filter list before the second item
-                        based
-                        on the sort key; without it, they would sort in reverse order based on the <span class="att">content</span> attribute. Note that the <span class="att">data-ssfiltersortkey</span> attribute name is all-lower-case, to comply with the XHTML5 schema.</div>
-                     </div>
+                        based on the sort key; without it, they would sort in reverse order based on the <span class="att">content</span> attribute. Note that the <span class="att">data-ssfiltersortkey</span> attribute name is all-lower-case, to comply with the XHTML5 schema.</div>
                   </div>
-               
+               </div>
                <div class="teidiv2" id="dateFilters">
-                  
                   <h3><span class="headingNumber">8.1.2 </span><span class="head">Date filters</span></h3>
-                  
                   <div class="p">Another slightly different kind of search control is a document date. If your collection
                      of documents has items from different dates, you can add a <span class="gi">&lt;meta&gt;</span> tag like this: 
-                     
                      <div id="index.xml-egXML-d38e297" class="pre egXML_valid"><span class="element">&lt;meta <span class="attribute">name</span>="<span class="attributevalue">Date of publication</span>"<br/> <span class="attribute">class</span>="<span class="attributevalue">staticSearch_date</span>" <span class="attribute">content</span>="<span class="attributevalue">1895-01-05</span>"/&gt;</span></div> The date may take any of the following forms: 
-                     
                      <ul>
-                        
                         <li class="item">1895 (year only)</li>
-                        
                         <li class="item">1895-01 (year and month)</li>
-                        
                         <li class="item">1895-01-05 (year, month and day)</li>
-                        </ul> For some documents, it may not be possible to specify a single date in this form,
+                     </ul> For some documents, it may not be possible to specify a single date in this form,
                      so you can specify a range instead, using a slash to separate the start and end dates
                      of the range (following ISO 8601): 
-                     
                      <ul>
-                        
                         <li class="item">1895/1897</li>
-                        
                         <li class="item">1903-01-02/1905-05-31</li>
-                        </ul>
-                     </div>
+                     </ul>
                   </div>
-               
+               </div>
                <div class="teidiv2" id="numFilters">
-                  
                   <h3><span class="headingNumber">8.1.3 </span><span class="head">Number filters</span></h3>
-                  
                   <div class="p">You can also configure a range filter based on a numeric value (integer or decimal).
                      For example, you might want to allow people to filter documents in the search results
                      based on their word-count: 
-                     
                      <div id="index.xml-egXML-d38e312" class="pre egXML_valid"><span class="element">&lt;meta <span class="attribute">name</span>="<span class="attributevalue">Word-count</span>"<br/> <span class="attribute">class</span>="<span class="attributevalue">staticSearch_num</span>" <span class="attribute">content</span>="<span class="attributevalue">2193</span>"/&gt;</span></div> Users would then be able to set a minimum and/or maximum word-count when searching
                      for documents.</div>
-                  </div>
-               
+               </div>
                <div class="teidiv2" id="boolFilters">
-                  
                   <h3><span class="headingNumber">8.1.4 </span><span class="head">Boolean filters</span></h3>
-                  
                   <div class="p">A fourth filter type is the boolean (true/false) filter. To use boolean filters, add
                      meta tags like this to your documents: 
-                     
                      <div id="index.xml-egXML-d38e319" class="pre egXML_valid"><span class="element">&lt;meta <span class="attribute">name</span>="<span class="attributevalue">Peer-reviewed</span>"<br/> <span class="attribute">class</span>="<span class="attributevalue">staticSearch_bool</span>" <span class="attribute">content</span>="<span class="attributevalue">true</span>"/&gt;</span></div>
-                     </div>
                   </div>
-               
+               </div>
                <div class="teidiv2" id="featFilters">
-                  
                   <h3><span class="headingNumber">8.1.5 </span><span class="head">Feature filters</span></h3>
-                  
                   <div class="p">The feature (feat) filter, just like a description filter, is a word or phrase describing
                      or associated with the document. Here is a simple example: 
-                     
                      <div id="index.xml-egXML-d38e325" class="pre egXML_valid"><span class="element">&lt;meta <span class="attribute">name</span>="<span class="attributevalue">People mentioned</span>"<br/> <span class="attribute">class</span>="<span class="attributevalue">staticSearch_feat</span>" <span class="attribute">content</span>="<span class="attributevalue">Nelson Mandela</span>"/&gt;</span></div> This specifies that there is to be a feature search filter called <span class="q">‘People mentioned’</span>, and one of the possible people is <span class="q">‘Nelson Mandela’</span>. This differs from a description filter in that the number of possible people (or
                      other feature) is expected to be large. If there are (for example) three hundred people
                      mentioned in the document collection, then using a description filter would result
@@ -672,25 +453,20 @@ function showByMod() {
                      the user can type some part of the feature they're searching for, and get a drop-down
                      list of matches. Selecting a match creates a checkbox in the search page, which then
                      functions just like a description filter. Here's another example: 
-                     
                      <div id="index.xml-egXML-d38e332" class="pre egXML_valid"><span class="element">&lt;meta <span class="attribute">name</span>="<span class="attributevalue">Postcodes mentioned</span>"<br/> <span class="attribute">class</span>="<span class="attributevalue">staticSearch_feat</span>" <span class="attribute">content</span>="<span class="attributevalue">V8W 1P4</span>"/&gt;</span></div> Obviously, a feature filter must be based on data that a searcher will be able to
                      predict. Searchers can also search for names or postcodes using the text search facility,
                      of course, but names might appear in different forms in different texts, so a feature
                      filter allows the user to find all instances of a particular person using the canonical
                      form of their name.</div>
-                  
                   <p>Note that feature filters have one drawback: they slow down the initialization of
                      the search page noticeably. In order to provide the typeahead/drop-down functionality,
                      the JSON for each feature filter will need to be retrieved as the page loads, so if
                      you have many feature filters, or particularly large ones, the user may have to wait
                      a few seconds before the page becomes fully functional.</p>
-                  </div>
                </div>
-            
+            </div>
             <div class="teidiv1" id="configuringDocTitles">
-               
                <h3><span class="headingNumber">8.2 </span><span class="head">Configuring your site: document titles</span></h3>
-               
                <div class="p">When the indexing process runs over your document collection, by default it will use
                   the document title that it finds in the <span class="gi">&lt;title&gt;</span> element in the document header; that title will then be shown as a link to the document
                   when it comes up in search results. However, that may not be the ideal title for this
@@ -698,128 +474,86 @@ function showByMod() {
                   part of their document title, but it would be pointless to include this in the search
                   result links. Therefore you can override the document title value by providing another
                   meta tag, like this: 
-                  
                   <div id="index.xml-egXML-d38e342" class="pre egXML_valid"><span class="element">&lt;meta <span class="attribute">name</span>="<span class="attributevalue">docTitle</span>"<br/> <span class="attribute">class</span>="<span class="attributevalue">staticSearch_docTitle</span>" <span class="attribute">content</span>="<span class="attributevalue">What I did in my holidays</span>"/&gt;</span></div>
-                  </div>
                </div>
-            
+            </div>
             <div class="teidiv1" id="configuringDocSortKey">
-               
                <h3><span class="headingNumber">8.3 </span><span class="head">Configuring your site: document sort keys</span></h3>
-               
                <div class="p">When a user searches for text on your site, the documents retrieved will be presented
                   in a sequence based on the ‘hit score’ or ‘relevance score’; documents with the highest
-                  scores will be presented first, and the list will be
-                  in descending order of relevance. However, if you have search filters on your site,
-                  it is possible that users will not enter any search text at all; they may simply select
-                  some filters and get a list of matching documents. In this case, there will be no
-                  relevance scores, so the documents will be presented in a random order. However, you
-                  may wish to control the order in which documents without hit scores, or sequences
-                  of documents with the same hit score, are presented. You can do this by adding a single
-                  meta tag to the document providing a ‘sort key’, which can be used to sort the list
-                  of hits. This is an example: 
-                  
+                  scores will be presented first, and the list will be in descending order of relevance.
+                  However, if you have search filters on your site, it is possible that users will not
+                  enter any search text at all; they may simply select some filters and get a list of
+                  matching documents. In this case, there will be no relevance scores, so the documents
+                  will be presented in a random order. However, you may wish to control the order in
+                  which documents without hit scores, or sequences of documents with the same hit score,
+                  are presented. You can do this by adding a single meta tag to the document providing
+                  a ‘sort key’, which can be used to sort the list of hits. This is an example: 
                   <div id="index.xml-egXML-d38e354" class="pre egXML_valid"><span class="element">&lt;meta <span class="attribute">name</span>="<span class="attributevalue">docSortKey</span>"<br/> <span class="attribute">class</span>="<span class="attributevalue">staticSearch_docSortKey</span>" <span class="attribute">content</span>="<span class="attributevalue">d_1854-01-02</span>"/&gt;</span></div>
-                  </div>
                </div>
-            
+            </div>
             <div class="teidiv1" id="configuringDocThumbnails">
-               
                <h3><span class="headingNumber">8.4 </span><span class="head">Configuring your site: document thumbnails</span></h3>
-               
                <div class="p">When a document is returned as a result of a search hit, you may want to include with
                   it a thumbnail image. This may be for aesthetic reasons, or because the focus of the
                   document itself is actually an image (perhaps your site is a set of pages dealing
                   with works of art, for instance). Whatever the reason, you can supply a link to a
                   thumbnail image like this: 
-                  
                   <div id="index.xml-egXML-d38e360" class="pre egXML_valid"><span class="element">&lt;meta <span class="attribute">name</span>="<span class="attributevalue">docImage</span>"<br/> <span class="attribute">class</span>="<span class="attributevalue">staticSearch_docImage</span>" <span class="attribute">content</span>="<span class="attributevalue">images/thisPage.jpg</span>"/&gt;</span></div> The <span class="att">content</span> attribute value should either be the path to an image relative to the document itself
                   or the URL to an external image; so in the example above, there would be a folder
                   called <span class="ident">images</span> which is a sibling of the HTML file containing the tag, and that folder would contain
                   a file called <span class="ident">thisPage.jpg</span>.</div>
-               </div>
-            
+            </div>
             <div class="teidiv1" id="creatingConfigFile">
-               
                <h3><span class="headingNumber">8.5 </span><span class="head">Creating a configuration file</span></h3>
-               
                <p>The configuration file is an XML document which tells the Generator where to find
                   your site, and what search features you would like to include. The configuration file
                   conforms to a schema which is documented here.</p>
-               
                <p>There are three main sections of the configuration file: </p>
-               
                <ul class="specList">
-                  
                   <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.params" title="&lt;params&gt;">params</a></span> (<span>Element containing most of the settings which enable the Generator to find the target
                         website content and process it appropriately.</span>)</li>
-                  
                   <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.rules" title="&lt;rules&gt;">rules</a></span> (<span>The set of rules that control weighting of search terms found in specific contexts.</span>)</li>
-                  
                   <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.contexts" title="&lt;contexts&gt;">contexts</a></span> (<span>The set of context elements that identify contexts for keyword-in-context fragments.</span>)</li>
-                  </ul>
-               
+               </ul>
                <p> Only the <a class="link_ref" href="#TEI.params" title="&lt;params&gt;">&lt;params&gt;</a> element is necessary, but, as we discuss shortly, we highly suggest taking advantage
                   of the <a class="link_ref" href="#TEI.rules" title="&lt;rules&gt;">&lt;rules&gt;</a> (see <a class="link_ptr" href="#specifyingRules" title="Specifying rules (optional)"><span class="headingNumber">8.5.3 </span>Specifying rules (optional)</a>) and <a class="link_ref" href="#TEI.contexts" title="&lt;contexts&gt;">&lt;contexts&gt;</a> (<a class="link_ptr" href="#specifyingContexts" title="Specifying contexts (optional)"><span class="headingNumber">8.5.4 </span>Specifying contexts (optional)</a>) for the best results.</p>
-               
                <p>For examples of full configuration files, see the <a class="link_ref" href="https://github.com/projectEndings/staticSearch">staticSearch GitHub repository</a> as well as the list of projects in <a class="link_ptr" href="#projectsUsingSS" title="Projects using staticSearch"><span class="headingNumber">12 </span>Projects using staticSearch</a>, which provides a link to each site’s configuration file.</p>
-               
                <div class="teidiv2" id="rootConfigElement">
-                  
                   <h3><span class="headingNumber">8.5.1 </span><span class="head">The <span class="gi">&lt;config&gt;</span> element</span></h3>
-                  
                   <div class="p">The configuration element has a root <a class="link_ref" href="#TEI.config" title="&lt;config&gt;">&lt;config&gt;</a> element in the staticSearch namespace (<span class="val">http://hcmc.uvic.ca/ns/staticSearch</span>): 
-                     
                      <div id="index.xml-egXML-d38e438" class="pre egXML_valid"><span class="element">&lt;config xmlns="http://hcmc.uvic.ca/ns/staticSearch"&gt;</span><br/> <span class="element">&lt;params&gt;</span><br/><span class="comment">&lt;!--Parameters--&gt;</span><br/> <span class="element">&lt;/params&gt;</span><br/> <span class="element">&lt;rules&gt;</span><br/><span class="comment">&lt;!--Rules--&gt;</span><br/> <span class="element">&lt;/rules&gt;</span><br/> <span class="element">&lt;contexts&gt;</span><br/><span class="comment">&lt;!--Contexts--&gt;</span><br/> <span class="element">&lt;/contexts&gt;</span><br/><span class="element">&lt;/config&gt;</span></div> The <a class="link_ref" href="#TEI.config" title="&lt;config&gt;">&lt;config&gt;</a> element may bear the optional <span class="att">version</span> attribute, which provides the major version number (i.e. a single integer value)
-                     of
-                     staticSearch that corresponds with the configuration file. 
-                     
+                     of staticSearch that corresponds with the configuration file. 
                      <ul class="specList">
-                        
                         <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.config" title="&lt;config&gt;">config</a></span> (<span>The root element for the Search Generator configuration file.</span>) 
-                           
                            <div class="table">
-                              
                               <table class="specDesc">
-                                 
                                  <tr>
-                                    
                                     <td class="Attribute"><span class="att">version</span></td>
-                                    
                                     <td>(<span>specifies the major version of staticSearch to which this configuration file corresponds.
                                           If this attribute is not used, the configuration file is assumed to have an version
                                           value of 1.</span>)</td>
-                                    </tr>
-                                 </table>
-                              </div>
-                           </li>
-                        </ul> Though optional, the <span class="att">version</span> attribute is recommended for all configuration files; future version of staticSearch
+                                 </tr>
+                              </table>
+                           </div>
+                        </li>
+                     </ul> Though optional, the <span class="att">version</span> attribute is recommended for all configuration files; future version of staticSearch
                      may introduce breaking changes to the structure and syntax of the configuration file,
                      which can be more easily detected by staticSearch when an <span class="att">version</span> is specified.</div>
-                  </div>
-               
+               </div>
                <div class="teidiv2" id="specifyingParameters">
-                  
                   <h3><span class="headingNumber">8.5.2 </span><span class="head">Specifying parameters</span></h3>
-                  
                   <div class="teidiv3" id="paramsRequired">
-                     
                      <h4><span class="headingNumber">8.5.2.1 </span><span class="head">Required parameters</span></h4>
-                     
                      <p>The <a class="link_ref" href="#TEI.params" title="&lt;params&gt;">&lt;params&gt;</a> element has two required elements for determining the resource collection that you
                         wish to index: </p>
-                     
                      <ul class="specList">
-                        
                         <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.searchFile" title="&lt;searchFile&gt;">searchFile</a></span> (<span>The search file (aka page) that will be the primary access point for the staticSearch.
                               Note that this page must be at the root of the collection directory.</span>)</li>
-                        
                         <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.recurse" title="&lt;recurse&gt;">recurse</a></span> (<span>Whether to recurse into subdirectories of the collection directory or not.</span>)</li>
-                        </ul>
-                     
+                     </ul>
                      <p> <span style="display:block" class="p">The search page is a regular HTML page which forms part of your site. The only important
                            characteristic it must have is a <span class="gi">&lt;div&gt;</span> element with <span class="att">id</span>=<span class="val">staticSearch</span>, whose contents will be rewritten by the staticSearch build process. See <a class="link_ptr" href="#searchPage" title="Creating a search page"><span class="headingNumber">8.6 </span>Creating a search page</a>.</span></p>
-                     
                      <p>The <a class="link_ref" href="#TEI.searchFile" title="&lt;searchFile&gt;">&lt;searchFile&gt;</a> element is a relative URI (resolved, like all URIs specified in the config file,
                         against the configuration file location) that points directly to the search page that
                         will be the primary access point for the search. Since the search file must be at
@@ -828,67 +562,43 @@ function showByMod() {
                         the necessary information for knowing what document collection to index and where
                         to put the output JSON. In other words, in specifying the location of your search
                         page, you are also specifying the location of your document collection. See <a class="link_ref" href="#searchPage" title="Creating a search page">Creating a search page</a> for more information on how to configure this file.</p>
-                     
                      <p>Note that all output files will be in a directory that is a sibling to the search
                         page. For instance, in a document collection that looks something like: </p>
-                     
                      <ul style="font-family: monospace">
-                        
                         <li class="item">myProject 
-                           
                            <ul>
-                              
                               <li class="item">novel.html</li>
-                              
                               <li class="item">poem.html</li>
-                              
                               <li class="item">shortstory.html</li>
-                              
                               <li class="item">search.html</li>
-                              </ul>
-                           </li>
-                        </ul>
-                     
+                           </ul>
+                        </li>
+                     </ul>
                      <p> The collection of Javascript and JSON files will be in a directory like so: </p>
-                     
                      <ul style="font-family: monospace">
-                        
                         <li class="item">myProject 
-                           
                            <ul>
-                              
                               <li class="item">novel.html</li>
-                              
                               <li class="item">poem.html</li>
-                              
                               <li class="item">shortstory.html</li>
-                              
                               <li class="item">search.html</li>
-                              
                               <li class="item"><em>staticSearch</em></li>
-                              </ul>
-                           </li>
-                        </ul>
-                     
+                           </ul>
+                        </li>
+                     </ul>
                      <p>We also require the <a class="link_ref" href="#TEI.recurse" title="&lt;recurse&gt;">&lt;recurse&gt;</a> element in the case where the document collection may be nested (as is common with
                         static sites generated from Jekyll or Wordpress). The <a class="link_ref" href="#TEI.recurse" title="&lt;recurse&gt;">&lt;recurse&gt;</a> element is a boolean (true or false) that determines whether or not to recurse into
                         the subdirectories of the collection and index those files.</p>
-                     </div>
-                  
+                  </div>
                   <div class="teidiv3" id="paramsOptional">
-                     
                      <h4><span class="headingNumber">8.5.2.2 </span><span class="head">Optional parameters</span></h4>
-                     
                      <p>The following parameters are optional, but most projects will want to specify some
                         of them:  </p>
-                     
                      <ul class="specList">
-                        
                         <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.versionFile" title="&lt;versionFile&gt;">versionFile</a></span> (<span>The relative path to a text file containing a single version identifier (such as 1.5,
                               123456, or 06ad419). This will be used to create unique filenames for JSON resources,
                               so that the browser will not use cached versions of older index files.</span>)</li>
-                        </ul>
-                     
+                     </ul>
                      <p> <span style="display:block" class="p"><a class="link_ref" href="#TEI.versionFile" title="&lt;versionFile&gt;">&lt;versionFile&gt;</a> enables you to specify the path to a plain-text file containing a simple version
                            number for the project. This might take the form of a software-release-style version
                            number such as <span class="val">1.5</span>, or it might be a Subversion revision number or a Git commit hash. It should not
@@ -899,48 +609,38 @@ function showByMod() {
                            files will not be used because the new version will have different filenames. The
                            path specified is relative to the location of the configuration file (or absolute,
                            if you wish).</span> </p>
-                     
                      <ul class="specList">
-                        
                         <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.phrasalSearch" title="&lt;phrasalSearch&gt;">phrasalSearch</a></span> (<span>Whether or not to support phrasal searches. If this is true, then the maxContexts
                               setting will be ignored, because all contexts are required to properly support phrasal
                               search.</span>)</li>
-                        </ul>
-                     
+                     </ul>
                      <p> <span style="display:block" class="p">Phrasal search functionality enables your users to search for specific phrases by
                            surrounding them with quotation marks (<code>"</code>), as in many search engines. In order to support this kind of search, <a class="link_ref" href="#TEI.createContexts" title="&lt;createContexts&gt;">&lt;createContexts&gt;</a> must also be set to true as we store contexts for all hits for each token in each
                            document. Turning this on will make the index larger, because all contexts must be
                            stored, but once the index is built, it has very little impact on the speed of searches,
                            so we recommend turning this on. The default value is true.</span> <span style="display:block" class="p">However, if your site is very large and your user base is unlikely to use phrasal
                            searching, it may not be worth the additional build time and increased index size.</span> </p>
-                     
                      <ul class="specList">
-                        
                         <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.stemmerFolder" title="&lt;stemmerFolder&gt;">stemmerFolder</a></span> (<span>The name of a folder inside the staticSearch /stemmers/ folder, in which the JavaScript
                               and XSLT implementations of stemmers can be found. If left blank, then the staticSearch
                               default English stemmer (en) will be used.</span>)</li>
-                        </ul>
-                     
+                     </ul>
                      <p> <span style="display:block" class="p">The staticSearch project currently has only two real stemmers: an implementation of
                            the Porter 2 algorithm for modern English, and an implementation of the French Snowball
                            stemmer. These appear in the <span class="ident">/stemmers/en/</span> and <span class="ident">/stemmers/fr/</span> folders. The default value for this parameter is <span class="val">en</span>; to use the French stemmer, use <span class="val">fr</span>. We will be adding more stemmers as the project develops. However, if your document
                            collection is not English or French, you have a couple of options, one hard and one
                            easy. </span></p>
-                     
                      <ul>
-                        
                         <li class="item"><em>Hard option</em>: implement your own stemmers. You will need to write two implementations of the stemmer
                            algorithm, one in XSLT (which must be named <span class="ident">ssStemmer.xsl</span>) and one in JavaScript (<span class="ident">ssStemmer.js</span>), and confirm that they both generate the same results. The XSLT stemmer is used
                            in the generation of the index files at build time, and the JavaScript version is
                            used to stem the user's input in the search page. You can look at the existing implementations
                            in the <span class="ident">/stemmers/en/</span> folder to see how the stemmers need to be constructed. Place your stemmers in a folder
                            called <span class="ident">/stemmers/[yourlang]/</span>, and specify <span class="val">yourlang</span> in the configuration file.</li>
-                        
                         <li class="item"><em>Easy option</em>: Use the <span class="ident">identity stemmer</span> (which is equivalent to turning off stemming completely), and make sure wildcard
                            searching is turned on. Then your users can search using wildcards instead of having
                            their search terms automatically stemmed. To do this, specify the value <span class="val">identity</span> in your configuration file.</li>
-                        </ul>
-                     
+                     </ul>
                      <p><span style="display:block" class="p"> Another alternative is the <span class="ident">stripDiacritics</span> stemmer. Like the <span class="ident">identity stemmer</span>, this is not really a stemmer at all; what it does is to strip out all combining
                            diacritics from tokens. This is a useful approach if you document collection contains
                            texts with accents and diacritics, but your users may be unfamiliar with the use of
@@ -950,23 +650,17 @@ function showByMod() {
                            and user-friendly search engine in the absence of a sophisticated stemmer, or for
                            cases where there are mixed languages so a single stemmer will not do. To use this
                            option, specify the value <span class="val">stripDiacritics</span> in your configuration file.</span> </p>
-                     
                      <ul class="specList">
-                        
                         <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.scoringAlgorithm" title="&lt;scoringAlgorithm&gt;">scoringAlgorithm</a></span> (<span>The scoring algorithm to use for ranking keyword results. Default is "raw" (i.e. weighted
                               counts)</span>)</li>
-                        </ul>
-                     
+                     </ul>
                      <p> <span style="display:block" class="p"><a class="link_ref" href="#TEI.scoringAlgorithm" title="&lt;scoringAlgorithm&gt;">&lt;scoringAlgorithm&gt;</a> is an optional element that specifies which scoring algorithm to use when calculating
                            the score of a term and thus the order in which the results from a search are sorted.
                            There are currently two options: </span></p>
-                     
                      <ul>
-                        
                         <li class="item"><span class="val">raw</span>: This is the default option (and so does not need to be set explicitly). The raw
                            score is simply the sum of all instances of a term (optionally multipled by a configured
                            weight via the <a class="link_ref" href="#TEI.rule" title="&lt;rule&gt;">&lt;rule&gt;</a>/<span class="att">weight</span> <a class="link_ref" href="#specifyingRules" title="Specifying rules (optional)">configuration</a>) in a document. This will usually provide good results for most document collections.</li>
-                        
                         <li class="item"><span class="val">tf-idf</span>: The tf-idf algorithm (term frequency-inverse document frequency) computes the mathematical
                            relevance of a term within a document relative to the rest of the document collection.
                            The staticSearch implementation of tf-idf basically follows the textbook definition
@@ -975,39 +669,29 @@ function showByMod() {
                            like <a class="link_ref" href="https://lucene.apache.org/core/3_5_0/scoring.html">Lucene</a>, but it may provide useful results for document collections of varying lengths or
                            in instances where the raw score may be insufficient or misleading. There are a number
                            of resources on tf-idf scoring, including: <a class="link_ref" href="https://en.wikipedia.org/wiki/Tf%E2%80%93idf">Wikipedia</a> and Christopher D. Manning, Prabhakar Raghavan and Hinrich Schütze, <a class="link_ref" href="https://nlp.stanford.edu/IR-book/html/htmledition/tf-idf-weighting-1.html">Introduction to Information Retrieval</a>, Cambridge University Press. 2008.</li>
-                        </ul>
-                     
+                     </ul>
                      <p> </p>
-                     
                      <ul class="specList">
-                        
                         <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.createContexts" title="&lt;createContexts&gt;">createContexts</a></span> (<span>Whether to include keyword-in-context extracts in the index.</span>)</li>
-                        </ul>
-                     
+                     </ul>
                      <p> <span style="display:block" class="p"><a class="link_ref" href="#TEI.createContexts" title="&lt;createContexts&gt;">&lt;createContexts&gt;</a> is a boolean parameter that specifies whether you want the indexer to store keyword-in-context
                            extracts for each of the hits in a document. This increases the size of the index,
                            but of course it makes for much more user-friendly search results; instead of seeing
                            just a score for each document found, the user will see a series of short text strings
                            with the search keyword(s) highlighted.</span> <span style="display:block" class="p">Note that contexts are necessary for phrasal searching or wildcard searching.</span> </p>
-                     
                      <ul class="specList">
-                        
                         <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.minWordLength" title="&lt;minWordLength&gt;">minWordLength</a></span> (<span>The minimum length of a term to be indexed. Default is 3 characters.</span>)</li>
-                        </ul>
-                     
+                     </ul>
                      <p> <span style="display:block" class="p"><a class="link_ref" href="#TEI.minWordLength" title="&lt;minWordLength&gt;">&lt;minWordLength&gt;</a> specifies the minimum length in characters of a sequence of text that will be considered
                            to be a word worth indexing. The default is 3, on the basis that in most European
                            languages, words of one or two letters are typically not worth indexing, being articles,
                            prepositions and so on. If you set this to a lower limit for reasons specific to your
                            project, you should ensure that your stopword list excludes any very common words
                            that would otherwise make the indexing process lengthy and increase the index size.</span> </p>
-                     
                      <ul class="specList">
-                        
                         <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.maxKwicsToHarvest" title="&lt;maxKwicsToHarvest&gt;">maxKwicsToHarvest</a></span> (<span>This controls the maximum number of keyword-in-context extracts that will be stored
                               for each term in a document.</span>)</li>
-                        </ul>
-                     
+                     </ul>
                      <p> <span style="display:block" class="p"><a class="link_ref" href="#TEI.maxKwicsToHarvest" title="&lt;maxKwicsToHarvest&gt;">&lt;maxKwicsToHarvest&gt;</a> controls the number of keyword-in-context extracts that will be harvested from the
                            data for each term in a document. For example, if a user searches for the word <span class="q">‘elephant’</span>, and it occurs 27 times in a document, but the <a class="link_ref" href="#TEI.maxKwicsToHarvest" title="&lt;maxKwicsToHarvest&gt;">&lt;maxKwicsToHarvest&gt;</a> value is set to 5, then only the first five (sorted in document order) of these keyword-in-context
                            strings will be stored in the index. (This does not affect the score of the document
@@ -1015,47 +699,35 @@ function showByMod() {
                            JSON files will be constrained, but of course the user will only be able to see the
                            KWICs that have been harvested in their search results.</span> <span style="display:block" class="p">If <a class="link_ref" href="#TEI.phrasalSearch" title="&lt;phrasalSearch&gt;">&lt;phrasalSearch&gt;</a> is set to true, the <a class="link_ref" href="#TEI.maxKwicsToHarvest" title="&lt;maxKwicsToHarvest&gt;">&lt;maxKwicsToHarvest&gt;</a> setting is ignored, because phrasal searches will only work properly if all contexts
                            are stored.</span> </p>
-                     
                      <ul class="specList">
-                        
                         <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.maxKwicsToShow" title="&lt;maxKwicsToShow&gt;">maxKwicsToShow</a></span> (<span>This controls the maximum number of keyword-in-context extracts that will be shown
                               in the search page for each hit document returned.</span>)</li>
-                        </ul>
-                     
+                     </ul>
                      <p> <span style="display:block" class="p">A user may search for multiple common words, so hundreds of hits could be found in
                            a single document. If the keyword-in-context strings for all these hits are shown
                            on the results page, it would be too long and too difficult to navigate. This setting
                            controls how many of those hits you want to show for each document in the result set.</span> </p>
-                     
                      <ul class="specList">
-                        
                         <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.totalKwicLength" title="&lt;totalKwicLength&gt;">totalKwicLength</a></span> (<span>If createContexts is set to true, then this parameter controls the length (in words)
                               of the harvested keyword-in-context string.</span>)</li>
-                        </ul>
-                     
+                     </ul>
                      <p> <span style="display:block" class="p">Obviously, the longer the keyword-in-context strings are, the larger the individual
                            index files will be, but the more useful the KWICs will be for users looking at the
                            search results. Note that the phrasal searching relies on the KWICs and thus longer
                            KWICs allow for longer phrasal searches.</span> </p>
-                     
                      <ul class="specList">
-                        
                         <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.kwicTruncateString" title="&lt;kwicTruncateString&gt;">kwicTruncateString</a></span> (<span>The string that will be used to signal ellipsis at the beginning and end of a keyword-in-context
                               extract. Conventionally three periods, or an ellipsis character (which is the default
                               value).</span>)</li>
-                        </ul>
-                     
+                     </ul>
                      <p> <span style="display:block" class="p">The only reason you might need to specify a value for this parameter is if the language
                            of your search page conventionally uses a different ellipsis character. Japanese,
                            for example, uses the 3-dot-leader character.</span> </p>
-                     
                      <ul class="specList">
-                        
                         <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.resultsPerPage" title="&lt;resultsPerPage&gt;">resultsPerPage</a></span> (<span>The maximum number of document results to be displayed per page. All results are displayed
                               by default; setting resultsPerPage to a positive integer creates a Show More/Show
                               All widget at the bottom of the batch of results.</span>)</li>
-                        </ul>
-                     
+                     </ul>
                      <p> <span style="display:block" class="p">For most sites, where the number of results is likely to be in the low thousands,
                            it's perfectly practical to show all the results at once, because the staticSearch
                            processor is so fast. However, if you have tens of thousands of documents, and it's
@@ -1064,13 +736,10 @@ function showByMod() {
                            using this setting. All the results are still generated and output to the page, but
                            since most of them are hidden until the ‘Show More’ or ‘Show All’ button is clicked,
                            the browser will render them much more quickly.</span> </p>
-                     
                      <ul class="specList">
-                        
                         <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.stopwordsFile" title="&lt;stopwordsFile&gt;">stopwordsFile</a></span> (<span>The relative path (from the config file) to a text file containing a list of stopwords
                               (words to be ignored when indexing). </span>)</li>
-                        </ul>
-                     
+                     </ul>
                      <p> <span style="display:block" class="p">A stopword is a word that will not be indexed, because it is too common (<span class="mentioned">the</span>, <span class="mentioned">a</span>, <span class="mentioned">you</span> and so on). There are common stopwords files for most languages available on the
                            Web, but it is probably a good idea to take one of these and customize it for your
                            project, since there will be words in the website which are so common that it makes
@@ -1080,13 +749,10 @@ function showByMod() {
                            stopwords for English, which you'll find in <span class="ident">xsl/english_stopwords.txt</span>. One way to find appropriate stopwords for your site is to generate your index, then
                            search for the largest JSON index files that are generated, to see if they might be
                            too common to be useful as search terms. You can also use the <span class="titlem">Word Frequency</span> table in the generated staticSearch report (see <a class="link_ptr" href="#theStaticSearchReport" title="Generated report"><span class="headingNumber">8.9 </span>Generated report</a>).</span>  </p>
-                     
                      <ul class="specList">
-                        
                         <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.dictionaryFile" title="&lt;dictionaryFile&gt;">dictionaryFile</a></span> (<span>The relative path (from the config file) to a dictionary file (one word per line)
                               which will be used to check tokens when indexing.</span>)</li>
-                        </ul>
-                     
+                     </ul>
                      <p> <span style="display:block" class="p">The indexing process checks each word as it builds the index, and keeps a record of
                            all words which are not found in the configured dictionary. Though this does not have
                            any direct effect in the indexing process, all words not found in the dictionary are
@@ -1094,127 +760,87 @@ function showByMod() {
                            of the dictionary) or perhaps misspelled (in which case they may not be correctly
                            stemmed and index, and should be corrected). There is a default dictionary in <span class="ident">xsl/english_words.txt</span> which you might copy and adapt if you're working in English; lots of dictionaries
                            for other languages are available on the Web.</span> </p>
-                     
                      <ul class="specList">
-                        
                         <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.outputFolder" title="&lt;outputFolder&gt;">outputFolder</a></span> (<span>The name of the output folder into which the index data and JavaScript will be placed
                               in the site search. This should conform with the XML Name specification.</span>)</li>
-                        </ul>
-                     
+                     </ul>
                      <p> <span style="display:block" class="p">When the staticSearch build process creates its output, many files need to be added
                            to the website for which an index is being created. For convenience, all of these
                            files are stored in a single folder. This element is used to specify the name of that
                            folder. The default is <span class="val">staticSearch</span>, but if you would prefer something else, you can specify it here. You may also use
                            this element if you are defining two different searches within the same site, so that
                            their files are kept in different locations.</span></p>
-                     </div>
                   </div>
-               
+               </div>
                <div class="teidiv2" id="specifyingRules">
-                  
                   <h3><span class="headingNumber">8.5.3 </span><span class="head">Specifying rules (optional)</span></h3>
-                  
                   <ul class="specList">
-                     
                      <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.rules" title="&lt;rules&gt;">rules</a></span> (<span>The set of rules that control weighting of search terms found in specific contexts.</span>)</li>
-                     
                      <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.rule" title="&lt;rule&gt;">rule</a></span> (<span>A rule that specifies a document path as XPath in the match attribute, and provides
                            weighting for search terms found in that context.</span>) 
-                        
                         <div class="table">
-                           
                            <table class="specDesc">
-                              
                               <tr>
-                                 
                                  <td class="Attribute"><span class="att">match [att.match]</span></td>
-                                 
                                  <td>(<span>An XPath equivalent to the @match attribute of an xsl:template, which specifies a
                                        context in a document.</span>)</td>
-                                 </tr>
-                              
+                              </tr>
                               <tr>
-                                 
                                  <td class="Attribute"><span class="att">weight</span></td>
-                                 
                                  <td>(<span>The weighting to give to a search token found in the context specified by the match
                                        attribute. Set to 0 to completely suppress indexing for a specific context, or greater
                                        than 1 to give stronger weighting.</span>)</td>
-                                 </tr>
-                              </table>
-                           </div>
-                        </li>
-                     </ul>
-                  
+                              </tr>
+                           </table>
+                        </div>
+                     </li>
+                  </ul>
                   <p> <span style="display:block" class="p">The rule element is used to identify nodes in the XHTML document collection which
                         should be treated in a special manner when indexed; either they might be ignored (if
                         <span class="att">weight</span>=<span class="val">0</span>), or any words found in them might be given greater weight than words in normal contexts
                         <span class="att">weight</span>&gt;<span class="val">1</span>. Words appearing in headings or titles, for example, might be weighted more heavily,
                         while navigation menus, banners, or footers might be ignored completely.</span></p>
-                  
                   <div class="p">The <a class="link_ref" href="#TEI.rules" title="&lt;rules&gt;">&lt;rules&gt;</a> elements specifies a list of conditions (using the <a class="link_ref" href="#TEI.rule" title="&lt;rule&gt;">&lt;rule&gt;</a> element) that tell the parser, using XPath statements in the <span class="att">match</span> attribute, specific weights to assign to particular parts of each document. For instance,
                      if you wanted all heading elements (<span class="gi">&lt;h1&gt;</span>, <span class="gi">&lt;h2&gt;</span>, etc) in documents to be given a greater weight and thus receive a higher score in
                      the results, you can do so using a rule like so: 
-                     
                      <div id="index.xml-egXML-d38e981" class="pre egXML_valid"><span class="element">&lt;rules&gt;</span><br/> <span class="element">&lt;rule <span class="attribute">weight</span>="<span class="attributevalue">2</span>"<br/>  <span class="attribute">match</span>="<span class="attributevalue">h1 | h2 | h3 | h4 | h5 | h6</span>"/&gt;</span><br/><span class="element">&lt;/rules&gt;</span></div> Since we're using XPath 3.0 and XSLT 3.0, this can also be simplified to: 
-                     
                      <div id="index.xml-egXML-d38e985" class="pre egXML_valid"><span class="element">&lt;rules&gt;</span><br/> <span class="element">&lt;rule <span class="attribute">weight</span>="<span class="attributevalue">2</span>"<br/>  <span class="attribute">match</span>="<span class="attributevalue">*[matches(local-name(),'^h\d+$')]</span>"/&gt;</span><br/><span class="element">&lt;/rules&gt;</span></div> (It is worth noting, however, the above example is unnecessary: all heading elements
                      are given a weight of 2 by default, which is the only preconfigured weight in staticSearch.)</div>
-                  
                   <p>The value of the <span class="att">match</span> attribute is transformed in a XSLT template match attribute, and thus must follow
                      the same rules (i.e. no complex rules like <code>p/ancestor::div</code>). See the <a class="link_ref" href="https://www.w3.org/TR/xslt-30/#dt-pattern">W3C XSLT Specification</a> for further details on allowable pattern rules.</p>
-                  
                   <div class="p">Often, there will be elements that you want the tokenizer to ignore completely; for
                      instance, if you have the same header in every document, then there's no reason to
                      index its contents on every page. These elements can be ignored simply by using a
                      <a class="link_ref" href="#TEI.rule" title="&lt;rule&gt;">&lt;rule&gt;</a> and setting its weight to 0. For instance, if you want to remove the header and the
                      footer from the search indexing process, you could write something like: 
-                     
                      <div id="index.xml-egXML-d38e1004" class="pre egXML_valid"><span class="element">&lt;rule <span class="attribute">weight</span>="<span class="attributevalue">0</span>" <span class="attribute">match</span>="<span class="attributevalue">footer | header</span>"/&gt;</span></div> Or if you want to remove XHTML anchor tags (<span class="gi">&lt;a&gt;</span>) whose text is identical to the URL specified in its <span class="att">href</span>, you could do something like: 
-                     
                      <div id="index.xml-egXML-d38e1012" class="pre egXML_valid"><span class="element">&lt;rule <span class="attribute">weight</span>="<span class="attributevalue">0</span>" <span class="attribute">match</span>="<span class="attributevalue">a[@href=./text()]</span>"/&gt;</span></div>
-                     </div>
-                  
+                  </div>
                   <p>Note that the indexer does not tokenize any content in the <span class="gi">&lt;head&gt;</span> of the document (but as noted in <a class="link_ptr" href="#filters" title="Configuring your site search filters"><span class="headingNumber">8.1 </span>Configuring your site: search filters</a>, metadata can be configured into filters) and that all elements in the <span class="gi">&lt;body&gt;</span> of a document are considered tokenizable. However, common elements that you might
                      want to exclude include: </p>
-                  
                   <ul>
-                     
                      <li class="item"><span class="gi">&lt;script&gt;</span></li>
-                     
                      <li class="item"><span class="gi">&lt;style&gt;</span></li>
-                     
                      <li class="item"><span class="gi">&lt;code&gt;</span></li>
-                     </ul>
-                  </div>
-               
+                  </ul>
+               </div>
                <div class="teidiv2" id="specifyingContexts">
-                  
                   <h3><span class="headingNumber">8.5.4 </span><span class="head">Specifying contexts (optional)</span></h3>
-                  
                   <ul class="specList">
-                     
                      <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.contexts" title="&lt;contexts&gt;">contexts</a></span> (<span>The set of context elements that identify contexts for keyword-in-context fragments.</span>)</li>
-                     
                      <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.context" title="&lt;context&gt;">context</a></span> (<span>A context definition, providing a match attribute that identifies the context, allowing
                            keyword-in-context fragments to be bounded by a specific context.</span>) 
-                        
                         <div class="table">
-                           
                            <table class="specDesc">
-                              
                               <tr>
-                                 
                                  <td class="Attribute"><span class="att">match [att.match]</span></td>
-                                 
                                  <td>(<span>An XPath equivalent to the @match attribute of an xsl:template, which specifies a
                                        context in a document.</span>)</td>
-                                 </tr>
-                              </table>
-                           </div>
-                        </li>
-                     </ul>
-                  
+                              </tr>
+                           </table>
+                        </div>
+                     </li>
+                  </ul>
                   <p> <span style="display:block" class="p">When the indexer is extracting keyword-in-context strings for each word, it uses a
                         common-sense approach based on common element definitions, so that for example when
                         it reaches the end of a paragraph, it will not continue into the next paragraph to
@@ -1222,107 +848,68 @@ function showByMod() {
                         which do not appear to be bounding contexts, but actually are; for example, you may
                         have span elements with <span class="att">class</span>=<span class="val">note</span> that appear in the middle of sentences but are not actually part of them. Use <a class="link_ref" href="#TEI.context" title="&lt;context&gt;">&lt;context&gt;</a> elements to identify these special contexts so that the indexer knows the right boundaries
                         from which to retrieve its keyword-in-context strings.</span></p>
-                  
                   <div class="p">When the staticSearch creates the keywords-in-context strings (the "kwic" or "snippets")
                      for each token, it does so by looking for the nearest block-level element that it
                      can use as its context. Take, for instance, this unordered list: 
-                     
                      <div id="index.xml-egXML-d38e1074" class="pre egXML_valid"><span class="element">&lt;ul&gt;</span><br/> <span class="element">&lt;li&gt;</span>Keyword-in-context search results. This is also configurable, since including contexts<br/>   increases the size of the index.<span class="element">&lt;/li&gt;</span><br/> <span class="element">&lt;li&gt;</span>Search filtering using any metadata you like, allowing users to limit their search
                         to specific<br/>   document types.<span class="element">&lt;/li&gt;</span><br/><span class="element">&lt;/ul&gt;</span></div> Each <span class="gi">&lt;li&gt;</span> elements is, by default, a <span class="term">context</span> element, meaning that the snippet generated for each token will not extend beyond
                      the <span class="gi">&lt;li&gt;</span> element boundaries; in this case, if the <span class="gi">&lt;li&gt;</span> was not a context attribute, the term <span class="q">‘search’</span> would produce a context that looks something like: 
-                     
                      <pre id="index.xml-eg-d38e1092" class="pre_eg">"...the size of the index.<span style="font-weight:bold;">Search</span> filtering using any metadata you like,..."<a href="#index.xml-eg-d38e1092" class="anchorlink">⚓</a></pre>
-                     </div>
-                  
+                  </div>
                   <div class="p">Using the <a class="link_ref" href="#TEI.contexts" title="&lt;contexts&gt;">&lt;contexts&gt;</a> element, you can control what elements operate as contexts. For instance, say a page
                      contained a marginal note, encoded as a <span class="gi">&lt;span&gt;</span> in your document beside its point of attachment:<span id="Note1_return"><a class="notelink" title="This example taken from Thomas S. Kuhn, The Structure of Scientific Revolutions (50th anniversary edition), University of Chicago Press, 2012: p. 191." href="#Note1"><sup>1</sup></a></span> 
-                     
                      <div id="index.xml-egXML-d38e1110" class="pre egXML_valid"><span class="element">&lt;p&gt;</span>About that program I shall have nothing to say here,<span class="element">&lt;span <span class="attribute">class</span>="<span class="attributevalue">sidenote</span>"&gt;</span>Some information on this subject can be found in "Second Thoughts"<span class="element">&lt;/span&gt;</span> [...]<br/><span class="element">&lt;/p&gt;</span></div> Using CSS, the footnote might be alongside the text of the document in margin, or
                      made into a clickable object using Javascript. However, since the tokenizer is unaware
                      of any server-side processing, it understands the <span class="gi">&lt;span&gt;</span> as an inline element and assumes the <span class="gi">&lt;p&gt;</span> constitutes the context of the element. A search for <span class="q">‘information’</span> might then return: 
-                     
                      <pre id="index.xml-eg-d38e1124" class="pre_eg">"...nothing to say here,Some <span style="font-weight:bold;">information</span> on this subject can be found...<a href="#index.xml-eg-d38e1124" class="anchorlink">⚓</a></pre> To tell the tokenizer that the <span class="gi">&lt;span&gt;</span> constitutes the context block for any of its tokens, use the <a class="link_ref" href="#TEI.context" title="&lt;context&gt;">&lt;context&gt;</a> element with an <span class="att">match</span> pattern: 
-                     
                      <div id="index.xml-egXML-d38e1139" class="pre egXML_valid"><span class="element">&lt;contexts&gt;</span><br/> <span class="element">&lt;context <span class="attribute">match</span>="<span class="attributevalue">span[contains-token(@class,'sidenote')]</span>"/&gt;</span><br/><span class="element">&lt;/contexts&gt;</span></div>
-                     </div>
-                  
+                  </div>
                   <div class="p">You can also configure it the other way: if a <span class="gi">&lt;div&gt;</span>, which is by default a context block, should not be understood as a context block,
                      then you can tell the parser to not consider it as such using <span class="att">context</span> set to false: 
-                     
                      <div id="index.xml-egXML-d38e1149" class="pre egXML_valid"><span class="element">&lt;contexts&gt;</span><br/> <span class="element">&lt;context <span class="attribute">match</span>="<span class="attributevalue">div</span>" <span class="attribute">context</span>="<span class="attributevalue">false</span>"/&gt;</span><br/><span class="element">&lt;/contexts&gt;</span></div>
-                     </div>
-                  
-                  <p>The default contexts elements are: </p>
-                  
-                  <ul>
-                     
-                     <li class="item"><span class="gi">&lt;body&gt;</span></li>
-                     
-                     <li class="item"><span class="gi">&lt;div&gt;</span></li>
-                     
-                     <li class="item"><span class="gi">&lt;blockquote&gt;</span></li>
-                     
-                     <li class="item"><span class="gi">&lt;p&gt;</span></li>
-                     
-                     <li class="item"><span class="gi">&lt;li&gt;</span></li>
-                     
-                     <li class="item"><span class="gi">&lt;section&gt;</span></li>
-                     
-                     <li class="item"><span class="gi">&lt;article&gt;</span></li>
-                     
-                     <li class="item"><span class="gi">&lt;nav&gt;</span></li>
-                     
-                     <li class="item"><span class="gi">&lt;h1&gt;</span></li>
-                     
-                     <li class="item"><span class="gi">&lt;h2&gt;</span></li>
-                     
-                     <li class="item"><span class="gi">&lt;h3&gt;</span></li>
-                     
-                     <li class="item"><span class="gi">&lt;h4&gt;</span></li>
-                     
-                     <li class="item"><span class="gi">&lt;h5&gt;</span></li>
-                     
-                     <li class="item"><span class="gi">&lt;h6&gt;</span></li>
-                     
-                     <li class="item"><span class="gi">&lt;td&gt;</span></li>
-                     </ul>
                   </div>
-               
+                  <p>The default contexts elements are: </p>
+                  <ul>
+                     <li class="item"><span class="gi">&lt;body&gt;</span></li>
+                     <li class="item"><span class="gi">&lt;div&gt;</span></li>
+                     <li class="item"><span class="gi">&lt;blockquote&gt;</span></li>
+                     <li class="item"><span class="gi">&lt;p&gt;</span></li>
+                     <li class="item"><span class="gi">&lt;li&gt;</span></li>
+                     <li class="item"><span class="gi">&lt;section&gt;</span></li>
+                     <li class="item"><span class="gi">&lt;article&gt;</span></li>
+                     <li class="item"><span class="gi">&lt;nav&gt;</span></li>
+                     <li class="item"><span class="gi">&lt;h1&gt;</span></li>
+                     <li class="item"><span class="gi">&lt;h2&gt;</span></li>
+                     <li class="item"><span class="gi">&lt;h3&gt;</span></li>
+                     <li class="item"><span class="gi">&lt;h4&gt;</span></li>
+                     <li class="item"><span class="gi">&lt;h5&gt;</span></li>
+                     <li class="item"><span class="gi">&lt;h6&gt;</span></li>
+                     <li class="item"><span class="gi">&lt;td&gt;</span></li>
+                  </ul>
+               </div>
                <div class="teidiv2" id="searchOnlyIn">
-                  
                   <h3><span class="headingNumber">8.5.5 </span><span class="head">Specifying searchable contexts (<span class="q">‘search only in’</span>)</span></h3>
-                  
                   <p>Pages may contain different kinds of blocks, or ‘contexts’, that need to be differentiated.
                      For example, consider a page for an online journal article, which includes the article’s
                      title, an abstract, the body of the article, and footnotes. Users may want to search
                      for terms only within abstracts or they may want to search only within the body of
                      the article, ignoring editorial and paratextual material.</p>
-                  
                   <div class="p">The <a class="link_ref" href="#TEI.context" title="&lt;context&gt;">&lt;context&gt;</a> mechanism provides a way to specify particular components of a page that can be searched
                      within using the <span class="att">label</span> attribute. 
-                     
                      <ul class="specList">
-                        
                         <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.contexts" title="&lt;contexts&gt;">contexts</a></span> (<span>The set of context elements that identify contexts for keyword-in-context fragments.</span>)</li>
-                        
                         <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.context" title="&lt;context&gt;">context</a></span> (<span>A context definition, providing a match attribute that identifies the context, allowing
                               keyword-in-context fragments to be bounded by a specific context.</span>) 
-                           
                            <div class="table">
-                              
                               <table class="specDesc">
-                                 
                                  <tr>
-                                    
                                     <td class="Attribute"><span class="att">label [att.labelled]</span></td>
-                                    
                                     <td>(<span>A string identifier specifying the name for a given context.</span>)</td>
-                                    </tr>
-                                 </table>
-                              </div>
-                           </li>
-                        </ul> 
-                     
+                                 </tr>
+                              </table>
+                           </div>
+                        </li>
+                     </ul> 
                      <p>When the indexer is extracting keyword-in-context strings for each word, it uses a
                         common-sense approach based on common element definitions, so that for example when
                         it reaches the end of a paragraph, it will not continue into the next paragraph to
@@ -1333,202 +920,143 @@ function showByMod() {
                      users to perform a search within only a particular component of the page. For instance,
                      for a page structured like the journal article mentioned above, we could specify the
                      abstract, the notes, and the document’s body like so: 
-                     
                      <div id="index.xml-egXML-d38e1248" class="pre egXML_valid"><span class="element">&lt;contexts&gt;</span><br/> <span class="element">&lt;context <span class="attribute">match</span>="<span class="attributevalue">article[@id='article_content']</span>"<br/>  <span class="attribute">label</span>="<span class="attributevalue">Article text only</span>"/&gt;</span><br/> <span class="element">&lt;context <span class="attribute">match</span>="<span class="attributevalue">div[contains-token(@class,'footnote')]</span>"<br/>  <span class="attribute">label</span>="<span class="attributevalue">Notes only</span>"/&gt;</span><br/> <span class="element">&lt;context <span class="attribute">match</span>="<span class="attributevalue">section[@id='abstract']</span>"<br/>  <span class="attribute">label</span>="<span class="attributevalue">Abstracts only</span>"/&gt;</span><br/> <span class="element">&lt;context <span class="attribute">match</span>="<span class="attributevalue">span[contains-token(@class,'inline-note')]</span>"<br/>  <span class="attribute">label</span>="<span class="attributevalue">Notes only</span>"/&gt;</span><br/><span class="element">&lt;/contexts&gt;</span></div> The generated search page will then contain a set of checkboxes derived from the
                      distinct <span class="att">label</span> values. There is no requirement for the <span class="att">label</span> values to be distinct, but any identical labels will be treated as identical contexts
                      (i.e. in the example above, searching for a string within "Notes only" will return
                      all results found within both the div elements with a <span class="att">class</span>="footnote" and the span elements with <span class="att">class</span>="inline-note".)</div>
-                  </div>
-               
+               </div>
                <div class="teidiv2" id="specifyingExclusions">
-                  
                   <h3><span class="headingNumber">8.5.6 </span><span class="head">Specifying exclusions (optional)</span></h3>
-                  
                   <ul class="specList">
-                     
                      <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.excludes" title="&lt;excludes&gt;">excludes</a></span> (<span>The set of exclusions, expressed as exclude elements, that control the subset of documents
                            or filters used for a particular search.</span>)</li>
-                     
                      <li class="item"><span class="specList-elementSpec"><a class="link_ref" href="#TEI.exclude" title="&lt;exclude&gt;">exclude</a></span> (<span>An exclusion definition, which excludes either documents or filters as defined by
                            an XPath in the match attribute.</span>) 
-                        
                         <div class="table">
-                           
                            <table class="specDesc">
-                              
                               <tr>
-                                 
                                  <td class="Attribute"><span class="att">type</span></td>
-                                 
                                  <td></td>
-                                 </tr>
-                              
+                              </tr>
                               <tr>
-                                 
                                  <td class="Attribute"><span class="att">match [att.match]</span></td>
-                                 
                                  <td>(<span>An XPath equivalent to the @match attribute of an xsl:template, which specifies a
                                        context in a document.</span>)</td>
-                                 </tr>
-                              </table>
-                           </div>
-                        </li>
-                     </ul>
-                  
+                              </tr>
+                           </table>
+                        </div>
+                     </li>
+                  </ul>
                   <p> <span style="display:block" class="p"><a class="link_ref" href="#TEI.exclude" title="&lt;exclude&gt;">&lt;exclude&gt;</a> can be used to identify documents or parts of documents that are to be omitted from
                         indexing, but, unlike setting <span class="gi">&lt;weight&gt;</span> to zero, should be retained during the indexing process. This is helpful in cases
                         where the text itself should be ignored by the indexer, but should still appear in
                         KWICs. Another common use is for multiple search engines/pages that each have their
                         own special features; in this case, you may want one specific search index/page to
                         ignore filter controls (HTML <span class="gi">&lt;meta&gt;</span> elements, as described in <a class="link_ptr" href="#searchFacetFeatures" title="Search facet features"><span class="headingNumber">5 </span>Search facet features</a>) which are provided to support other search pages.</span></p>
-                  
                   <p>A complex site may have two or more search pages targetting specific types of document
                      or content, each of which may need its own particular search controls and indexes.
                      This can easily be achieved by specifying a different <a class="link_ref" href="#TEI.searchFile" title="&lt;searchFile&gt;">&lt;searchFile&gt;</a> and <a class="link_ref" href="#TEI.outputFolder" title="&lt;outputFolder&gt;">&lt;outputFolder&gt;</a> in the configuration file for each search.</p>
-                  
                   <div class="p">For these searches to be different from each other, they will also probably have different
                      contexts and rules. For example, imagine that you are creating a special search page
                      that focuses only on the text describing images or figures in your documents. You
                      might do it like this: 
-                     
                      <div id="index.xml-egXML-d38e1324" class="pre egXML_valid"><span class="element">&lt;rules&gt;</span><br/> <span class="element">&lt;rule <span class="attribute">match</span>="<span class="attributevalue">text()[not(ancestor::div[@class='figure']or ancestor::title)]</span>"<br/>  <span class="attribute">weight</span>="<span class="attributevalue">0</span>"/&gt;</span><br/><span class="element">&lt;/rules&gt;</span></div> This specifies that all text nodes which are not part of the document title or descendants
                      of <span class="tag">&lt;div class="figure"&gt;</span> should be ignored (<span class="att">weight</span>=<span class="val">0</span>), so only your target nodes will be indexed.</div>
-                  
                   <p>However, it's also likely that you will want to exclude certain features or documents
                      from a specialized search page, and this is done using the <a class="link_ref" href="#TEI.excludes" title="&lt;excludes&gt;">&lt;excludes&gt;</a> section and its child <a class="link_ref" href="#TEI.exclude" title="&lt;exclude&gt;">&lt;exclude&gt;</a> elements.</p>
-                  
                   <div class="p">Here is an example: 
-                     
                      <div id="index.xml-egXML-d38e1347" class="pre egXML_valid"><span class="element">&lt;excludes&gt;</span><br/><span class="comment">&lt;!-- We only index files which have illustrations in them. --&gt;</span><br/> <span class="element">&lt;exclude <span class="attribute">type</span>="<span class="attributevalue">index</span>"<br/>  <span class="attribute">match</span>="<span class="attributevalue">html[not(descendant::meta[@name='Has illustration(s)'][@content='true'])]</span>"/&gt;</span><br/><span class="comment">&lt;!-- We ignore the document type filter, 
                            because we are only indexing one type 
                            of document anyway. --&gt;</span><br/> <span class="element">&lt;exclude <span class="attribute">type</span>="<span class="attributevalue">filter</span>"<br/>  <span class="attribute">match</span>="<span class="attributevalue">meta[@name='Document type']</span>"/&gt;</span><br/><span class="comment">&lt;!-- We exclude the filter that specifies 
                            these documents because it's pointless. --&gt;</span><br/> <span class="element">&lt;exclude <span class="attribute">type</span>="<span class="attributevalue">filter</span>"<br/>  <span class="attribute">match</span>="<span class="attributevalue">meta[@name='Has illustration(s)']</span>"/&gt;</span><br/><span class="element">&lt;/excludes&gt;</span></div> Here we use <span class="tag">&lt;exclude type="index"/&gt;</span> to specify that all documents which do not contain <span class="tag">&lt;meta name="Has illustration(s)" content="true"/&gt;&gt;</span> should be ignored. Then we use two <span class="tag">&lt;exclude type="filter"/&gt;</span> tags to specify first that the <span class="ident">Document type</span> filter should be ignored (i.e. it should not appear on the search page), and second,
                      that the boolean filter <span class="ident">Has illustrations(s)</span> should also be excluded.</div>
-                  
                   <p>Using exclusions, you can create multiple specialized search pages which have customized
                      form controls within the same document collection. This is at the expense of additional
                      disk space and build time, of course; each of these searches needs to be built separately.</p>
-                  </div>
                </div>
-            
+            </div>
             <div class="teidiv1" id="searchPage">
-               
                <h3><span class="headingNumber">8.6 </span><span class="head">Creating a search page</span></h3>
-               
                <div class="p">You'll obviously want the search page for your site to conform with the look and feel
                   of the rest of your site. You can create a complete HTML document (which must of course
                   also be well-formed XML, so it can be processed), containing all the site components
                   you need, and then the search build process will insert all the necessary components
                   into that file. The only requirement is that the page contains one <span class="gi">&lt;div&gt;</span> element with the correct <span class="att">id</span> attribute: 
-                  
                   <div id="index.xml-egXML-d38e1380" class="pre egXML_valid"><span class="element">&lt;div <span class="attribute">id</span>="<span class="attributevalue">staticSearch</span>"&gt;</span> <br/> [...content will be supplied by the build process...]<br/><span class="element">&lt;/div&gt;</span></div> This <span class="gi">&lt;div&gt;</span> will be empty initially. The build process will find insert the search controls,
-                  scripts
-                  and results <span class="gi">&lt;div&gt;</span> into this container. Then whenever you rebuild the search for your site, the contents
+                  scripts and results <span class="gi">&lt;div&gt;</span> into this container. Then whenever you rebuild the search for your site, the contents
                   will be replaced. There is no need to make sure it's empty every time.</div>
-               
                <div class="p">The search process will also add a link to the staticSearch CSS file to the <span class="gi">&lt;head&gt;</span> of the document: 
-                  
                   <div id="index.xml-egXML-d38e1392" class="pre egXML_valid"><span class="element">&lt;link <span class="attribute">rel</span>="<span class="attributevalue">stylesheet</span>"<br/> <span class="attribute">href</span>="<span class="attributevalue">staticSearch/ssSearch.css</span>" <span class="attribute">id</span>="<span class="attributevalue">ssCss</span>"/&gt;</span></div> You can customize this CSS by providing your own CSS that overrides it, using <span class="gi">&lt;style&gt;</span>, or <span class="gi">&lt;link&gt;</span>, placed after it in the <span class="gi">&lt;head&gt;</span> element, or by replacing the inserted CSS after the build process. Note that some
                   features, like <a class="link_ref" href="#TEI.resultsPerPage" title="&lt;resultsPerPage&gt;">&lt;resultsPerPage&gt;</a> or the <span class="quote">‘Searching’</span> loading dialog, rely on rules included in the base staticSearch CSS; if you do remove
                   or disable the CSS, then some features may not work properly.</div>
-               
                <p>Note that once your file has been processed and all this content has been added, you
                   can process it again at any time; there is no need to start every time with a clean,
                   empty version of the search page.</p>
-               
                <p>You can take a look at the <span class="ident">test/search.html</span> page for an example of how to configure the search page (although note that since
                   this page has already been processed, it has the CSS and the search controls embedded
                   in it; it also has some additional JavaScript which we use for testing the search
                   build results, which is not necessary for your site).</p>
-               </div>
-            
+            </div>
             <div class="teidiv1" id="searchBuildProcess">
-               
                <h3><span class="headingNumber">8.7 </span><span class="head">Running the search build process</span></h3>
-               
                <p>Once you have configured your HTML and your configuration file, you're ready to create
                   a search index and a search page for your site. This requires that you run ant in
                   the root folder of the staticSearch project that you have downloaded or cloned.</p>
-               
                <p>Note: you will need Java and <a class="link_ref" href="https://ant.apache.org/">Apache Ant</a> installed, as well as <a class="link_ref" href="http://ant-contrib.sourceforge.net/">ant-contrib</a>.</p>
-               
                <p>Before running the search on your own site, you can test that your system is able
                   to do the build by doing the (very quick) build of the test materials. If you simply
                   run the <span class="ident">ant</span> command, like this:</p>
-               
                <pre id="index.xml-eg-d38e1427" class="pre_eg cdata">mholmes@linuxbox:~/Documents/staticSearch$ ant<a href="#index.xml-eg-d38e1427" class="anchorlink">⚓</a></pre>
-               
                <p>you should see a build process proceed using the small test collection of documents,
                   and at the end, a results page should open up giving you a report on what was done.
                   If this fails, then you'll need to troubleshoot the problem based on any error messages
                   you see. (Do you have Java, Ant and ant-contrib installed and working on your system?).</p>
-               
                <p>If the test succeeds, you can view the results by uploading the <span class="ident">test</span> folder and all its contents to a web server, or by running a local webserver on your
                   machine in that folder, using the <a class="link_ref" href="https://docs.python.org/3.8/library/http.server.html">Python HTTP server</a> or <a class="link_ref" href="https://www.php.net/manual/en/features.commandline.webserver.php">PHP's built-in web server</a>.</p>
-               
                <p>If the tests all work, then you're ready to build a search for your own site. Now
                   you need to run the same command, but this time, tell the build process where to find
                   your custom configuration file:<span id="Note2_return"><a class="notelink" title="Note that you can use either ssConfigFile or ssConfig to provide the build with the full path or relative path, respectively, of your configuration fi…" href="#Note2"><sup>2</sup></a></span></p>
-               
                <pre id="index.xml-eg-d38e1447" class="pre_eg cdata">ant -DssConfigFile=/home/mholmes/mysite/config_staticSearch.xml<a href="#index.xml-eg-d38e1447" class="anchorlink">⚓</a></pre>
-               
                <p>The same process should run, and if it's successful, you should have a modified <span class="ident">search.html</span> page as well as a lot of index files in JSON format in your site HTML folder. Now
                   you can test your own search in the same ways suggested above.</p>
-               </div>
-            
+            </div>
             <div class="teidiv1" id="callingStaticSearchFromAnt">
-               
                <h3><span class="headingNumber">8.8 </span><span class="head">Running staticSearch from Ant</span></h3>
-               
                <div class="p">staticSearch can be integrated into existing ant build processes quite easily. Once
                   cloned (or downloaded) from GitHub, the staticSearch codebase can be called by a build
                   process using the <code>ant</code> target with a nested <span class="gi">&lt;property&gt;</span> value that points to your staticSearch config file (either relative to staticSearch
                   using <code>ssConfig</code> or an absolute path using <code>ssConfigFile</code>). Assuming that the build file, your config file, and your staticSearch directory
                   are all at the root of the project, you could call the staticSearch build in ant like
                   so: 
-                  
                   <div id="index.xml-egXML-d38e1465" class="pre egXML_valid"><span class="element">&lt;ant <span class="attribute">antfile</span>="<span class="attributevalue">${basedir}/staticSearch</span>"<br/> <span class="attribute">inheritall</span>="<span class="attributevalue">false</span>"&gt;</span><br/> <span class="element">&lt;property <span class="attribute">name</span>="<span class="attributevalue">ssConfig</span>"<br/>  <span class="attribute">value</span>="<span class="attributevalue">staticSearch_config.xml</span>"/&gt;</span><br/><span class="element">&lt;/ant&gt;</span></div>
-                  </div>
-               
+               </div>
                <div class="p">Note that any arguments passed to ant at the command line arguments will be passed
                   on to the staticSearch build. This can cause issues when the main build requires the
                   use of the <code>-lib</code> parameter (since the project's version of Saxon may conflict, for instance, with
-                  the
-                  version used by staticSearch). If your build requires the use of the <code>-lib</code> parameter, then an alternative approach for calling staticSearch from your build
-                  is
-                  to use the <code>exec</code> task like so: 
-                  
+                  the version used by staticSearch). If your build requires the use of the <code>-lib</code> parameter, then an alternative approach for calling staticSearch from your build
+                  is to use the <code>exec</code> task like so: 
                   <div id="index.xml-egXML-d38e1476" class="pre egXML_valid"><span class="element">&lt;exec <span class="attribute">executable</span>="<span class="attributevalue">ant</span>" <span class="attribute">dir</span>="<span class="attributevalue">staticSearch</span>"&gt;</span><br/> <span class="element">&lt;arg <span class="attribute">value</span>="<span class="attributevalue">-DssConfig=../config_staticSearch.xml</span>"/&gt;</span><br/><span class="element">&lt;/exec&gt;</span></div>
-                  </div>
                </div>
-            
+            </div>
             <div class="teidiv1" id="theStaticSearchReport">
-               
                <h3><span class="headingNumber">8.9 </span><span class="head">Generated report</span></h3>
-               
                <p>After indexing your HTML files, the staticSearch build then generates an HTML report
                   of helpful statistics and diagnostics about your document collection, which can be
                   found in the directory specified by <a class="link_ref" href="#TEI.outputFolder" title="&lt;outputFolder&gt;">&lt;outputFolder&gt;</a>. We recommend looking at this file regularly, especially if you're encountering unexpected
                   behaviour by the staticSearch engine, as it contains information that can often help
                   diagnose issues with configured filters or the HTML document collection that, if fixed,
                   can improve staticSearch results.</p>
-               
                <p>By default, the report includes only basic information about the number of stem files
                   created, the the filters used, and any problems encountered. However, if you run the
                   build process using the additional parameter <span class="ident">ssVerboseReport</span>: </p>
-               
                <pre id="index.xml-eg-d38e1490" class="pre_eg cdata">ant -DssVerboseReport=true -DssConfigFile=...<a href="#index.xml-eg-d38e1490" class="anchorlink">⚓</a></pre>
-               
                <p> then the report will also include a number of tables that outline some statistics
                   about your project. <em>However, please note that compiling these statistics is very memory-intensive and
                      if your site is large, it may cause the build process to run out of memory.</em></p>
-               
                <p>As of version 1.4, the word frequency table is a separate document and is no longer
                   included as part of the verbose report. Instead, after running a build, you can then
                   build just the word frequency table with the special <span class="ident">concordance</span> target: </p>
-               
                <pre id="index.xml-eg-d38e1497" class="pre_eg cdata">ant -DssConfigFile=path/to/your/config.xml concordance<a href="#index.xml-eg-d38e1497" class="anchorlink">⚓</a></pre>
-               
                <p> While the chart itself is not necessary for the core functionality of staticSearch,
                   it is particularly useful during the initial development of a project’s search engine;
                   it can be used to create and fine-tune the project-specific stopword list (i.e. if
@@ -1538,55 +1066,40 @@ function showByMod() {
                   that statistical data used to generate the HTML view. It contains a JSON object that
                   lists each stem, its variants; each variant lists each document and the number of
                   times it appears within that document.</p>
-               
                <p>The concordance target comes with the same warning as above: compiling these statistics
                   is memory-intensive and may cause the build process to run out of memory.</p>
-               </div>
-            
+            </div>
             <div class="teidiv1" id="advancedFeatures">
-               
                <h3><span class="headingNumber">8.10 </span><span class="head">Advanced features</span></h3>
-               
                <div class="teidiv2" id="customAttributes">
-                  
                   <h3><span class="headingNumber">8.10.1 </span><span class="head">Custom attributes</span></h3>
-                  
                   <p>The search index will automatically link each keyword-in-context extract with the
                      closest element that has an <span class="att">id</span>, so that each keyword-in-context string in a search result will point directly to
                      a specific page fragment. You can also add your own attributes to any element in your
                      document in order to have those attributes appear on the keyword-in-context (KWIC)
                      result string (which is in the form of an HTML <span class="gi">&lt;li&gt;</span> element).</p>
-                  
                   <div class="p">Imagine that some of the paragraphs in your documents are special in some way. You
                      could add an attribute whose name begins with <span class="ident">data-ss-</span> to each of those paragraphs, like this: 
-                     
                      <div id="index.xml-egXML-d38e1515" class="pre egXML_valid"><span class="element">&lt;p <span class="attribute">data-ss-type</span>="<span class="attributevalue">special</span>"&gt;</span>This paragraph is special for some reason or other...<span class="element">&lt;/p&gt;</span></div> When the staticSearch indexer creates KWIC extracts, it automatically harvests any
                      attribute whose name begins with <span class="ident">data-ss-</span> from the containing element or its ancestors, and adds them to the keyword-in-context
                      record in the index. Then when that KWIC string is displayed as the result of a search,
                      the attribute will be added to the HTML <span class="gi">&lt;li&gt;</span> element on the page: 
-                     
                      <div id="index.xml-egXML-d38e1523" class="pre egXML_valid"><span class="element">&lt;li <span class="attribute">data-ss-type</span>="<span class="attributevalue">special</span>"&gt;</span>[KWIC with marked search hit, link, etc.]<span class="element">&lt;/li&gt;</span></div> This means that you can add your own CSS or JavaScript to make that KWIC appear distinct
                      from other KWICs which come from non-special paragraphs.</div>
-                  
                   <p>You can add as many custom attributes as you like (although bear in mind that they
                      increase the size of the index JSON files slightly and may add to the build time).</p>
-                  
                   <div class="p">One specific custom attribute has built-in handling that you may find useful. If you
                      add the attribute <span class="att">data-ss-img</span> with a value that points to an image, that image will be displayed to the left of
                      the KWIC string. For example, if you do this: 
-                     
                      <div id="index.xml-egXML-d38e1533" class="pre egXML_valid"><span class="element">&lt;p <span class="attribute">data-ss-img</span>="<span class="attributevalue">images/elephant.png</span>"&gt;</span>This paragraph is all about elephants...<span class="element">&lt;/p&gt;</span></div> then any KWIC results from that paragraph will show the <span class="ident">elephant.png</span> image to the left of the KWIC text. This can be especially useful if your site contains
                      large documents which are broken into sections, and those sections can be helpfully
                      represented by images; the search results will be easier for the user to understand
                      by virtue of the associated images. Image URLs should be relative to the location
                      of the search page, not the original source document, since the images will be displayed
                      on the search page.</div>
-                  </div>
-               
+               </div>
                <div class="teidiv2" id="highlightTargetPage">
-                  
                   <h3><span class="headingNumber">8.10.2 </span><span class="head">Highlighting search hits on target pages</span></h3>
-                  
                   <p>When you use a conventional search engine which is based on a backend database and
                      configured for a specific dynamic website, it is not unusual to find that when you
                      follow a link to a search hit on a target page, the hit will be highlighted on that
@@ -1595,43 +1108,31 @@ function showByMod() {
                      pages. However, if this is important to you, there is a workaround that you can use.
                      Since staticSearch does not modify your web pages, though, the implementation has
                      to be done by you.</p>
-                  
                   <p>By default each keyword-in-context result that shows on the search page will have
                      its own specific link to the fragment of the document which contains the hit. We strongly
                      recommend that you ensure your target documents have id attributes for any significant
                      divisions so that result links are as precise as possible, making the search results
                      much more useful.</p>
-                  
                   <p>Those links are also provided with a search string, like this: <code>https://example.com/egPage.html?ssMark=elephant#animals</code> This link points to the section of the document which has <span class="att">id</span>=<span class="val">animals</span>, but it also says <span class="q">‘the hit text is the word <span class="mentioned">elephant</span>.’</span> Some JavaScript that runs on the target page, <span class="ident">egPage.html</span> (which you control) will be able to parse the value of the query parameter <span class="ident">ssMark</span> in order to find the hit text, and highlight it in some way.</p>
-                  
                   <p>Obviously you can implement this any way you like (or just ignore it), but we also
                      supply a small demonstration JavaScript library which implements this functionality,
                      called <span class="ident">ssHighlight.js</span>. This JS file is included into the staticSearch output folder (see <a class="link_ref" href="#TEI.outputFolder" title="&lt;outputFolder&gt;">&lt;outputFolder&gt;</a>) by default, and if you include it into the header of your own pages, it will probably
                      do the highlighting without further intervention. If, however, you have lots of existing
                      JavaScript that runs when the page loads, there may be some interference between this
                      library and your own code, so you may have to make some adjustments to the code.</p>
-                  </div>
                </div>
-            </section>
-         
+            </div>
+         </section>
          <section class="teidiv0" id="howDoesItWork">
-            
             <header>
-               
                <h2><span class="headingNumber">9 </span><span class="head">How does it work?</span></h2>
-               </header>
-            
+            </header>
             <ul>
-               
                <li class="item">Level: Advanced</li>
-               
                <li class="item">Last Updated: <span class="date">12 May 2021</span></li>
-               </ul>
-            
+            </ul>
             <div class="teidiv1" id="buildingTheIndex">
-               
                <h3><span class="headingNumber">9.1 </span><span class="head">Building the index</span></h3>
-               
                <p>The tokenizing process first processes your configuration file to create an XSLT file
                   with all your settings embedded in it. Next, it processes your document collection
                   using those settings. Each document is tokenized, and then a separate JSON file is
@@ -1639,27 +1140,21 @@ function showByMod() {
                   which contain that token, as well as keyword-in-context strings for the actual tokens.
                   There will most likely be thousands of these files, but most of them are quite small.
                   These constitute the textual index.</p>
-               
                <p>In addition, separate JSON files are created for the list of document titles, and
                   for your stopword list if you have specified one. A single text file is also created
                   containing all the unique terms in the collection, used when doing wildcard searches.</p>
-               
                <p>Next, if you have specified search facets in your document headers, the processor
                   will then create a separate JSON file for each of those search facets, consisting
                   of a list of the document identifiers for all documents which match the filters; so
                   if some of your documents are specified as ‘Illustrated’ and some not (true or false),
                   a JSON file will be created for the ‘Illustrated’ facet, with a list of documents
                   which are true for this facet, and a list of documents which are false.</p>
-               
                <p>Finally, the template file you have created for the search page on your site will
                   be processed to add the required search controls and JavaScript to make the search
                   work.</p>
-               </div>
-            
+            </div>
             <div class="teidiv1" id="theSearchPage">
-               
                <h3><span class="headingNumber">9.2 </span><span class="head">The search page</span></h3>
-               
                <p>In order to provide fast, responsive search results, the search page must download
                   only the information it needs for each specific search. Obviously, if it were to download
                   the entire collection of thousands of token files, the process would take forever.
@@ -1667,7 +1162,6 @@ function showByMod() {
                   specific word, which is very rapid. (If you are using a different stemmer, of course,
                   then the token will be stemmed to a different output. If you are using the <span class="ident">identity stemmer</span>, then the token will be unchanged; with the <span class="ident">stripDiacritics</span> pseudo-stemmer, all combining diacritics will be stripped from the search terms,
                   as they are in the corresponding index.)</p>
-               
                <p>However, there is some information that is required for all or many searches. To display
                   any results, the list of document titles must be downloaded, for example. A user may
                   for instance use the search facets only, not searching for a particular word or phrase
@@ -1676,42 +1170,32 @@ function showByMod() {
                   advantage in having the JavaScript start downloading some of the essential files (titles,
                   stopwords and so on) as soon as the page loads, and it also starts downloading the
                   facet files in the background.</p>
-               
                <p>At the same time, though, we don't want to clog up the connection downloading these
                   files when the user may do a simple text search which doesn't depend on them, so these
                   files are retrieved using a ‘trickle’ approach, one at a time. Then if a search is
                   initiated, all the files required for that specific search can be downloaded as fast
                   as possible overriding the trickle sequence for files that are needed immediately.</p>
-               
                <p>One exception to the trickle approach is the case of Feature filters (where a user
                   can select search facets based on a typeahead control). Their JSON files be downloaded
                   to the browser before the typeahead control can be functional, so if you have feature
                   facets in your search, you will see an additional delay before the search page is
                   responsive.</p>
-               
                <p>Once the user has been on the search page for any length of time, all ancillary files
                   will have been retrieved (assuming they weren't already cached by the browser), so
                   the only files required for any search are those for the actual text search terms;
                   the response should therefore be even faster for later searches than for early ones.</p>
-               </div>
-            
+            </div>
             <div class="teidiv1" id="jsCompilation">
-               
                <h3><span class="headingNumber">9.3 </span><span class="head">JavaScript compilation</span></h3>
-               
                <p>The search page created for your website is entirely driven by JavaScript. The JavaScript
                   source code can be found in a number of <span class="ident">.js</span> files inside the repository <span class="ident">js</span> folder. At build time, these files (with the exception of <a class="link_ref" href="#highlightTargetPage" title="Highlighting search hits on target pages"><span class="ident">ssHighlight.js</span></a> and <a class="link_ref" href="#jsInitialization" title="The JavaScript Initializer file"><span class="ident">ssInitialize.js</span></a>) are first concatenated into a single large file called <span class="ident">ssSearch-debug.js</span>. This file is then optimized using the <a class="link_ref" href="https://github.com/google/closure-compiler/">Google Closure Compiler</a>, to create a smaller file called <span class="ident">ssSearch.js</span> which should be faster for the browser to download and parse. Both of these output
                   files are provided in your project <a class="link_ref" href="#TEI.outputFolder" title="&lt;outputFolder&gt;">&lt;outputFolder&gt;</a>; <span class="ident">ssSearch.js</span> is linked in your search page, but if you're having problems and would like to debug
                   with more human-friendly JavaScript, you can switch that link to point to <span class="ident">ssSearch-debug.js</span>.</p>
-               
                <p>We are still experimenting with the options and affordances of the Closure compiler,
                   in the interests of finding the best balance between file size and performance. </p>
-               </div>
-            
+            </div>
             <div class="teidiv1" id="jsInitialization">
-               
                <h3><span class="headingNumber">9.4 </span><span class="head">The JavaScript Initializer file</span></h3>
-               
                <p>When your search page is created, in addition to the main <span class="ident">ssSearch.js</span> file, an additional tiny JavaScript file, <span class="ident">ssInitialize.js</span>, is also linked into the page. The only purpose of this script is to create a variable
                   for the StaticSearch object and to initialize the object, which causes the search
                   functionality to be set up on the page. We do this in a separate file so that if you
@@ -1720,878 +1204,553 @@ function showByMod() {
                   file and manage the initialization of the StaticSearch object with your own code.
                   In early versions of staticSearch, this code was injected directly into a <span class="gi">&lt;script&gt;</span> tag within the search page, but since Content Security Policy settings increasingly
                   object to inline JavaScript, we have abstracted it into a separate file.</p>
-               </div>
-            </section>
-         
+            </div>
+         </section>
          <section class="teidiv0" id="howDoI">
-            
             <header>
-               
                <h2><span class="headingNumber">10 </span><span class="head"><span class="q">‘How do I...’</span></span></h2>
-               </header>
-            
+            </header>
             <p>Below are some of the most common things you might want to do using staticSearch:</p>
-            
             <div class="table">
-               
                <table>
-                  
                   <tr>
-                     
                      <td>How do I get staticSearch to ignore large chunks of my document?</td>
-                     
                      <td>Any element with a weight of 0 is ignored completely by the indexer, so add a <a class="link_ref" href="#TEI.rule" title="&lt;rule&gt;">&lt;rule&gt;</a> for the element. So to ignore all elements with the class <span class="val">ignoreThisElement</span>, you could do something like: 
-                        
                         <div id="index.xml-egXML-d38e1669" class="pre egXML_valid"><span class="element">&lt;rule <span class="attribute">weight</span>="<span class="attributevalue">0</span>"<br/> <span class="attribute">match</span>="<span class="attributevalue">div[contains-token(@class,'ignoreThisElement')</span>"/&gt;</span></div>
-                        </td>
-                     </tr>
-                  
+                     </td>
+                  </tr>
                   <tr>
-                     
                      <td>How do I get staticSearch to ignore small inline bits and <em>not</em> have them in the KWIC?</td>
-                     
                      <td>As above, you can use a <a class="link_ref" href="#TEI.rule" title="&lt;rule&gt;">&lt;rule&gt;</a> with an <span class="att">weight</span>=<span class="val">0</span></td>
-                     </tr>
-                  
+                  </tr>
                   <tr>
-                     
                      <td>How do I get staticSearch to ignore an element, but retain its text in the KWIC?</td>
-                     
                      <td>Here, you'll want to use the <a class="link_ref" href="#TEI.exclude" title="&lt;exclude&gt;">&lt;exclude&gt;</a> function, which excludes the element from indexing, but doesn't remove it from the
                         document itself. So, if you wanted to exclude all keyboard entry items (<span class="gi">&lt;xh:kbd&gt;</span>), but still have them in the KWIC, you could do something like: 
-                        
                         <div id="index.xml-egXML-d38e1695" class="pre egXML_valid"><span class="element">&lt;exclude <span class="attribute">match</span>="<span class="attributevalue">kbd</span>"<br/> <span class="attribute">type</span>="<span class="attributevalue">index</span>"/&gt;</span></div>
-                        </td>
-                     </tr>
-                  
+                     </td>
+                  </tr>
                   <tr>
-                     
                      <td>How can I get staticSearch to show debugging messages?</td>
-                     
                      <td>Set the <code>ssVerbose</code> property to true at the command line: 
-                        
                         <pre id="index.xml-eg-d38e1703" class="pre_eg cdata">ant -DssConfig=cfg.xml -DssVerbose=true <a href="#index.xml-eg-d38e1703" class="anchorlink">⚓</a></pre> Note that verbosity settings persist after creating the initial config; so, if you
                         are trying to debug just the tokenization process, you must make sure to run the config
                         target beforehand: 
-                        
                         <pre id="index.xml-eg-d38e1705" class="pre_eg cdata">ant config tokenize -DssConfig=cfg.xml -DssVerbose=true <a href="#index.xml-eg-d38e1705" class="anchorlink">⚓</a></pre>
-                        </td>
-                     </tr>
-                  
+                     </td>
+                  </tr>
                   <tr>
-                     
                      <td>How can I get staticSearch to highlight the found text in a target document?</td>
-                     
                      <td>There are two approaches to this: you could implement a JavaScript solution as explained
                         in <a class="link_ref" href="#highlightTargetPage" title="Highlighting search hits on target pages">Highlighting search hits on target pages</a>, or you could turn on the <span class="gi">&lt;scrollToFragmentId&gt;</span> experimental feature supported by some Chromium-based browsers. The former requires
                         some modification to your site pages to add some JavaScript, while the latter is non-standard
                         and not really reliable or consistent.</td>
-                     </tr>
-                  
+                  </tr>
                   <tr>
-                     
                      <td>How do I prevent staticSearch from encountering out of memory errors?</td>
-                     
                      <td>If you are indexing a very large collection of files, you may need to provide ant
                         with additional memory by configuring the ANT_OPTS system property. To provide ant
                         with 4GB of memory, you could do something like so: 
-                        
                         <pre id="index.xml-eg-d38e1719" class="pre_eg cdata">export ANT_OPTS="-Xmx4g"; ant -DssConfigFile=/absolute/path/to/your/config.xml<a href="#index.xml-eg-d38e1719" class="anchorlink">⚓</a></pre> How much memory you can and should provide to Ant depends on your particular system
                         and the size of the document collection. See <a class="link_ref" href="https://ant.apache.org/manual/install.html">Ant's documentation</a> for some further examples and explanation.</td>
-                     </tr>
-                  </table>
-               </div>
-            </section>
-         
+                  </tr>
+               </table>
+            </div>
+         </section>
          <section class="teidiv0" id="newSinceVersion1">
-            
             <header>
-               
                <h2><span class="headingNumber">11 </span><span class="head">What's new since version 1.0?</span></h2>
-               </header>
-            
+            </header>
             <ul>
-               
                <li class="item">Level: Intermediate</li>
-               
                <li class="item">Last Updated: <span class="date">7 March 2023</span></li>
-               </ul>
-            
+            </ul>
             <div class="teidiv1" id="newIn2.0">
-               
                <h3><span class="headingNumber">11.1 </span><span class="head">Changes in version 2.0</span></h3>
-               
                <p>Windows support has been added courtesy of a pull request from Tony Graham, and we
                   will continue to test and maintain it from now on.</p>
-               
                <p>staticSearch 2.0 contains breaking changes and improvements to staticSearch. In particular,
                   the configuration file has been significantly re-organized; configuration files made
                   for earlier versions of staticSearch <em>will not</em> work in 2.0.</p>
-               
                <div class="table">
-                  
                   <table>
-                     
                      <tr class="label">
-                        
                         <td class="label">Configuration Option</td>
-                        
                         <td class="label">Explanation</td>
-                        </tr>
-                     
+                     </tr>
                      <tr>
-                        
                         <td><span class="gi">&lt;verbose&gt;</span></td>
-                        
                         <td>The verbose option has been removed and replaced by the <code>ssVerbose</code> property in ant. To get debugging messages, set the ssVerbose parameter to true (other
                            accepted values: t, yes, y, 1) 
-                           
                            <pre id="index.xml-eg-d38e1753" class="pre_eg cdata">ant -DssConfig=cfg.xml -DssVerbose=true <a href="#index.xml-eg-d38e1753" class="anchorlink">⚓</a></pre>
-                           </td>
-                        </tr>
-                     
+                        </td>
+                     </tr>
                      <tr>
-                        
                         <td><span class="gi">&lt;indentJSON&gt;</span></td>
-                        
                         <td><span class="gi">&lt;indentJSON&gt;</span> has been removed since it is rarely necessary other than for debugging purposes,
-                           which
-                           can be better handled by other tools (i.e. viewed in Firefox or using the command-line
+                           which can be better handled by other tools (i.e. viewed in Firefox or using the command-line
                            tool jq).</td>
-                        </tr>
-                     
+                     </tr>
                      <tr>
-                        
                         <td><a class="link_ref" href="#TEI.linkToFragmentId" title="&lt;linkToFragmentId&gt;">&lt;linkToFragmentId&gt;</a></td>
-                        
                         <td><a class="link_ref" href="#TEI.linkToFragmentId" title="&lt;linkToFragmentId&gt;">&lt;linkToFragmentId&gt;</a>, which controlled whether the search results should link back to the nearest document
                            fragment with an <span class="att">id</span>, has been made part of the default behaviour of staticSearch and is no longer configurable.
                            However, if you do not want the link to the nearest fragment to appear in the results,
                            you can visually hide the link element with the <span class="ident">fidLink</span> class in your site's CSS: 
-                           
                            <pre id="index.xml-eg-d38e1773" class="pre_eg cdata">.fidLink{ display:none; } <a href="#index.xml-eg-d38e1773" class="anchorlink">⚓</a></pre>
-                           </td>
-                        </tr>
-                     
+                        </td>
+                     </tr>
                      <tr>
-                        
                         <td><span class="gi">&lt;scrollToTextFragment&gt;</span></td>
-                        
                         <td>The <span class="gi">&lt;scrollToTextFragment&gt;</span> option, which relied on the experimental <a class="link_ref" href="https://wicg.github.io/scroll-to-text-fragment/">Text Fragments specification</a>, has been removed. A more reliable alternative is to use JavaScript to <a class="link_ref" href="#highlightTargetPage" title="Highlighting search hits on target pages">highlight hits on the target page</a>.</td>
-                        </tr>
-                     </table>
-                  </div>
+                     </tr>
+                  </table>
                </div>
-            
+            </div>
             <div class="teidiv1" id="newIn1.4.3">
-               
                <h3><span class="headingNumber">11.2 </span><span class="head">Changes in version 1.4.3</span></h3>
-               
                <p>Minor enhancement:</p>
-               
                <ul>
-                  
                   <li class="item">The user-provided search string is now normalized to Unicode Normalization Form NFC
                      before being processed, and a user-overridable preprocessing function has been added
                      to the search-string parsing code. This will be documented in a future release.</li>
-                  </ul>
-               </div>
-            
+               </ul>
+            </div>
             <div class="teidiv1" id="newIn1.4.2">
-               
                <h3><span class="headingNumber">11.3 </span><span class="head">Changes in version 1.4.2</span></h3>
-               
                <p>Bug fix:</p>
-               
                <ul>
-                  
                   <li class="item">A bug which could cause a divide-by-zero error in the JSON generation stage of the
                      build when the target site consisted of fewer than ten documents was fixed via a pull
                      request from Norman Walsh. Thanks Norman!</li>
-                  </ul>
-               </div>
-            
+               </ul>
+            </div>
             <div class="teidiv1" id="newIn1.4.1">
-               
                <h3><span class="headingNumber">11.4 </span><span class="head">Changes in version 1.4.1</span></h3>
-               
                <p>Bug fix:</p>
-               
                <ul>
-                  
                   <li class="item">A minor bug whereby a rare combination of circumstances could lead to document hit
                      scores being reported as concatenated numbers rather than summed numbers has been
                      fixed.</li>
-                  </ul>
-               </div>
-            
+               </ul>
+            </div>
             <div class="teidiv1" id="newIn1.4">
-               
                <h3><span class="headingNumber">11.5 </span><span class="head">Changes in version 1.4</span></h3>
-               
                <p>Deprecations requiring changes to existing projects:</p>
-               
                <ul>
-                  
                   <li class="item">Filter sort keys must be declared using the all lower-cased data attribute <span class="att">data-ssfiltersortkey</span>. While the documentation in <a class="link_ptr" href="#descFilterSorting" title="Sort order for description filters"><span class="headingNumber">8.1.1.1 </span>Sort order for description filters</a> correctly specified the attribute's name, the processing code only accepted the camel-case
                      version, which is invalid XHTML5. In 1.4, using <span class="att">data-ssFilterSortKey</span> will result in WARNINGs; in all subsequent versions, using the camel-case attribute
                      name will result in build failures.</li>
-                  </ul>
-               
+               </ul>
                <p>New features and enhancements:</p>
-               
                <ul>
-                  
                   <li class="item">A new <a class="link_ref" href="#searchOnlyIn" title="Specifying searchable contexts (search only in)">Search only in</a> feature has been added. This enables you to specify regions of documents and label
                      them using the <span class="att">label</span> attribute on <a class="link_ref" href="#TEI.context" title="&lt;context&gt;">&lt;context&gt;</a> (per issue <a class="link_ref" href="https://github.com/projectEndings/staticSearch/issues/20">#20</a>). Users can then check only the regions they would like to get search results from.</li>
-                  
                   <li class="item">A new <a class="link_ref" href="#featFilters" title="Feature filters">feature filter</a> has been added to the collection of search facets. This provides an option for cases
                      where the number of items in a description filter might be so large that providing
                      a long list of individual checkboxes for all the options is not practical. Instead,
                      the feature filter offers a method of finding and selecting items using a typeahead
                      control.</li>
-                  
                   <li class="item">Search page controls are now <a class="link_ref" href="https://www.w3.org/WAI/WCAG2AA-Conformance">WCAG2</a>-compliant.</li>
-                  
                   <li class="item">When you navigate back or forward to a previous search, if any of the filters which
                      were used in that search are hidden inside closed HTML details elements, those elements
                      will be opened.</li>
-                  
                   <li class="item">A noscript element is now inserted into the search page to handle cases where JavaScript
                      is turned off in the user's browser.</li>
-                  
                   <li class="item">A ‘Loading...’ splash screen is shown when the search page is initially configuring
                      itself.</li>
-                  
                   <li class="item">All inline CSS and JavaScript has now been moved to external files, to better suit
                      Content Security Policy constraints.</li>
-                  
                   <li class="item">The staticSearch report has been simplified and no longer produces a concordance of
                      stems by default. The concordance can be built at the command line by calling the
                      <code>concordance</code> target in ant: 
-                     
                      <pre id="index.xml-eg-d38e1853" class="pre_eg cdata">ant concordance -DssConfig=cfg.xml<a href="#index.xml-eg-d38e1853" class="anchorlink">⚓</a></pre>
-                     </li>
-                  
+                  </li>
                   <li class="item">The <span class="att">version</span> attribute has been added to the root <a class="link_ref" href="#TEI.config" title="&lt;config&gt;">&lt;config&gt;</a> element to better future-proof the alignment of configuration files and the staticSearch
                      codebase. See <a class="link_ptr" href="#rootConfigElement" title="The config element"><span class="headingNumber">8.5.1 </span>The config element</a> for more details.</li>
-                  </ul>
-               
+               </ul>
                <p>Bug fixes:</p>
-               
                <ul>
-                  
                   <li class="item">A bug which caused number filters to be ignored when navigating back to a previous
                      search has been fixed.</li>
-                  
                   <li class="item">A bug which caused the tokenizer to assume wordbreaks when encountering certain diacritics
                      has been fixed.</li>
-                  </ul>
-               
+               </ul>
                <p>All issues and tickets related to version 1.4 can be found on <a class="link_ref" href="https://github.com/projectEndings/staticSearch/issues?q=is%3Aissue+milestone%3A%22Release+1.4%22+">GitHub</a>.</p>
-               </div>
-            
+            </div>
             <div class="teidiv1" id="newIn1.3">
-               
                <h3><span class="headingNumber">11.6 </span><span class="head">Changes in version 1.3</span></h3>
-               
                <p>Note that version 1.2 was withdrawn in favour of version 1.3, so the list below includes
                   changes from the original version 1.2 and the current 1.3.</p>
-               
                <p>Deprecations requiring changes to existing projects:</p>
-               
                <ul>
-                  
                   <li class="item">All staticSearch classes with periods have been deprecated in favour of underscores
                      as periods in class names conflict with the standard "." chaining selector in CSS
                      and JavaScript. (See <a class="link_ref" href="https://github.com/projectEndings/staticSearch/issues/149">issue 149</a> for the full discussion.) <em>This affects the majority of staticSearch meta classes, which should be changed from
                         <span class="val">staticSearch.</span> to <span class="val">staticSearch_</span>; see the full list below:</em> 
-                     
                      <div class="table">
-                        
                         <table>
-                           
                            <tr class="label">
-                              
                               <td>DEPRECATED VALUE</td>
-                              
                               <td>REPLACE WITH</td>
-                              </tr>
-                           
+                           </tr>
                            <tr>
-                              
                               <td>staticSearch.desc</td>
-                              
                               <td>staticSearch_desc</td>
-                              </tr>
-                           
+                           </tr>
                            <tr>
-                              
                               <td>staticSearch.bool</td>
-                              
                               <td>staticSearch_bool</td>
-                              </tr>
-                           
+                           </tr>
                            <tr>
-                              
                               <td>staticSearch.num</td>
-                              
                               <td>staticSearch_num</td>
-                              </tr>
-                           
+                           </tr>
                            <tr>
-                              
                               <td>staticSearch.date</td>
-                              
                               <td>staticSearch_date</td>
-                              </tr>
-                           
+                           </tr>
                            <tr>
-                              
                               <td>staticSearch.docTitle</td>
-                              
                               <td>staticSearch_docTitle</td>
-                              </tr>
-                           
+                           </tr>
                            <tr>
-                              
                               <td>staticSearch.docImage</td>
-                              
                               <td>staticSearch_docImage</td>
-                              </tr>
-                           
+                           </tr>
                            <tr>
-                              
                               <td>staticSearch.docSortKey</td>
-                              
                               <td>staticSearch_docSortKey</td>
-                              </tr>
-                           </table>
-                        </div> For version 1.3, using the deprecated period syntax will result in WARNINGs; in all
+                           </tr>
+                        </table>
+                     </div> For version 1.3, using the deprecated period syntax will result in WARNINGs; in all
                      subsequent versions, using the period syntax will result in build failures.</li>
-                  
                   <li class="item">The original parameters <span class="val">config</span> and <span class="val">configFile</span> have been renamed <span class="val">ssConfig</span> and <span class="val">ssConfigFile</span> to minimize the chances of naming collisions with parameters in other build processes.
                      <em>IF YOU HAVE SCRIPTED A staticSearch BUILD AS PART OF YOUR OWN BUILD PROCESS, YOU WILL
                         NEED TO UPDATE THESE PARAMETER NAMES.</em></li>
-                  </ul>
-               
+               </ul>
                <p>New features and enhancements:</p>
-               
                <ul>
-                  
                   <li class="item">The JavaScript source code has now been split into several distinct source files,
                      and is compiled and optimized using the Google Closure Compiler at build time. See
                      <a class="link_ref" href="#jsCompilation" title="JavaScript compilation">JavaScript compilation</a> for more information.</li>
-                  
                   <li class="item">Support for French in captions etc. in the search page has been improved.</li>
-                  
                   <li class="item">A French stemmer is now available, as well as a caption set for French search pages.</li>
-                  
                   <li class="item">Images can now be configured for specific parts of a document, as well as for the
                      whole document, for display alongside KWICs in results. This is part of a new extension
                      mechanism using <a class="link_ref" href="#customAttributes" title="Custom attributes">custom attributes</a>.</li>
-                  
                   <li class="item">The CSS for the search page inserted by the indexing process is now more easily accessible
                      in a separate file <span class="ident">css/ssSearch.css</span>, which is linked into the search page at build time.</li>
-                  
                   <li class="item">Links to target documents from keyword-in-context results now include a search string
                      parameter that specifies the hit text, so that JavaScript running in the target page
                      can highlight the search hit(s) and scroll to them. See <a class="link_ref" href="#highlightTargetPage" title="Highlighting search hits on target pages">Highlighting search hits on target pages</a> for more information.</li>
-                  
                   <li class="item">Documentation has been significantly improved with additional explanatory remarks
                      for many elements, and the staticSearch build of the documentation now includes hit
                      highlighting (the feature described above).</li>
-                  
                   <li class="item">Only ancestor ids are indexed when <a class="link_ref" href="#TEI.linkToFragmentId" title="&lt;linkToFragmentId&gt;">&lt;linkToFragmentId&gt;</a> is enabled; formerly, any preceding id value was used.</li>
-                  
                   <li class="item">Results can now optionally be viewed in batches by setting the new <a class="link_ref" href="#TEI.resultsPerPage" title="&lt;resultsPerPage&gt;">&lt;resultsPerPage&gt;</a> configuration option.</li>
-                  
                   <li class="item">The maximum number of results that a search can return has been set to 2000 results
                      by default and can be changed using the new <a class="link_ref" href="#TEI.resultsLimit" title="&lt;resultsLimit&gt;">&lt;resultsLimit&gt;</a> element. If a search returns a set of results that exceeds this limit, staticSearch
                      does not render the results and advises the user to try a more precise search.</li>
-                  
                   <li class="item">The minimum length of a word to be indexed is now configurable, so in unusual circumstances
                      you can now enable searching for 1- or 2-letter words using the <a class="link_ref" href="#TEI.minWordLength" title="&lt;minWordLength&gt;">&lt;minWordLength&gt;</a> parameter.</li>
-                  
                   <li class="item">The staticSearch report is now discussed in the documentation (see <a class="link_ptr" href="#theStaticSearchReport" title="Generated report"><span class="headingNumber">8.9 </span>Generated report</a>) and the "Not in Dictionary" and "Foreign Words" reports have been improved.</li>
-                  
                   <li class="item">The filter creation process has been rationalized such that all filter processing
                      happens in <code>json.xsl</code>, which has also improved the build performance slightly.</li>
-                  </ul>
-               
+               </ul>
                <p>Bug fixes:</p>
-               
                <ul>
-                  
                   <li class="item">The encoding structure for docImage, docSortKey, and docTitle has been constrained
                      such that each doc* <span class="gi">&lt;meta&gt;</span> must include both a <span class="att">name</span> and <span class="att">class</span> value: 
-                     
                      <div id="index.xml-egXML-d38e1998" class="pre egXML_valid"><span class="element">&lt;meta <span class="attribute">name</span>="<span class="attributevalue">docTitle</span>"<br/> <span class="attribute">class</span>="<span class="attributevalue">staticSearch_docTitle</span>" <span class="attribute">content</span>="<span class="attributevalue">My custom document title</span>"/&gt;</span></div>
-                     </li>
-                  
+                  </li>
                   <li class="item">Temporary XML files from dictionaries are now removed during the <code>clean</code> step of the build process.</li>
-                  
                   <li class="item">All HTML characters are properly escaped in context snippets.</li>
-                  </ul>
-               </div>
-            
+               </ul>
+            </div>
             <div class="teidiv1" id="newIn1.1">
-               
                <h3><span class="headingNumber">11.7 </span><span class="head">Changes in version 1.1</span></h3>
-               
                <p>New features and enhancements:</p>
-               
                <ul>
-                  
                   <li class="item">Search results can now be sorted using a <a class="link_ref" href="#configuringDocSortKey" title="Configuring your site document sort keys">user-supplied sort key</a>. This is useful when searching only with filters (so all documents have the same
                      relevance score) or where many results have the same relevance score.</li>
-                  
                   <li class="item">Using the new <a class="link_ref" href="#TEI.linkToFragmentId" title="&lt;linkToFragmentId&gt;">&lt;linkToFragmentId&gt;</a> parameter, keyword-in-context results can now have individual links to nearest ancestor
                      fragment id, so the searcher can go directly to the relevant section of a document.</li>
-                  
                   <li class="item">The order of parameter elements in the configuration file is no longer fixed. The
                      schema now allows elements to appear in any order.</li>
-                  
                   <li class="item">We have added a new <a class="link_ref" href="#howDoI" title="How do I...">How Do I...</a> section in the documentation.</li>
-                  
                   <li class="item">Phrasal searches are now case-sensitive, meaning that you can use a ‘phrasal search’
                      to search for proper names, by putting quotation marks around them and making the
                      first letter upper-case.</li>
-                  
                   <li class="item">Indexing is faster and the size of the index is smaller because we have eliminated
                      the upper-case index.</li>
-                  </ul>
-               
+               </ul>
                <p>Bug fixes:</p>
-               
                <ul>
-                  
                   <li class="item">URL containing empty search query string caused unwanted page scroll.</li>
-                  
                   <li class="item">The build process would fail to open the search report when running under very recent
                      versions of Java.</li>
-                  
                   <li class="item">Punctuation is no longer stripped from phrasal searches, so searching for longer phrases
                      including punctuation should be more successful.</li>
-                  </ul>
-               </div>
-            </section>
-         
-         <section class="teidiv0" id="projectsUsingSS">
-            
-            <header>
-               
-               <h2><span class="headingNumber">12 </span><span class="head">Projects using staticSearch</span></h2>
-               </header>
-            
-            <ul>
-               
-               <li class="item">Level: Basic</li>
-               
-               <li class="item">Last Updated: <span class="date">7 March 2023</span></li>
                </ul>
-            
+            </div>
+         </section>
+         <section class="teidiv0" id="projectsUsingSS">
+            <header>
+               <h2><span class="headingNumber">12 </span><span class="head">Projects using staticSearch</span></h2>
+            </header>
+            <ul>
+               <li class="item">Level: Basic</li>
+               <li class="item">Last Updated: <span class="date">7 March 2023</span></li>
+            </ul>
             <div class="table">
-               
                <table>
-                  
                   <tr class="label">
-                     
                      <td>Name</td>
-                     
                      <td>Search Page(s)</td>
-                     
                      <td>Configuration file(s)</td>
-                     </tr>
-                  
+                  </tr>
                   <tr>
-                     
                      <td><a class="link_ref" href="https://mapoflondon.uvic.ca">The Map of Early Modern London</a></td>
-                     
                      <td><a class="link_ref" href="https://mapoflondon.uvic.ca/search.htm">Search</a></td>
-                     
                      <td><a class="link_ref" href="https://hcmc.uvic.ca/svn/london/static/config_staticSearch.xml">SVN</a></td>
-                     </tr>
-                  
+                  </tr>
                   <tr>
-                     
                      <td><a class="link_ref" href="https://winnifredeatonarchive.org">The Winnifred Eaton Archive</a></td>
-                     
                      <td><a class="link_ref" href="https://winnifredeatonarchive.org/search.html">Search</a></td>
-                     
                      <td><a class="link_ref" href="https://github.com/winnifredeatonarchive/wea_data/blob/09ae8660007a10e23e80e2f5769aec0bf1f919c6/code/staticSearch/config.xml">Github</a></td>
-                     </tr>
-                  
+                  </tr>
                   <tr>
-                     
                      <td><a class="link_ref" href="https://johnkeats.uvic.ca/">Mapping Keat's Progress</a></td>
-                     
                      <td><a class="link_ref" href="https://johnkeats.uvic.ca/search.html">Search</a></td>
-                     
                      <td><a class="link_ref" href="https://hcmc.uvic.ca/svn/keats/config_staticSearch.xml">SVN</a></td>
-                     </tr>
-                  
+                  </tr>
                   <tr>
-                     
                      <td><a class="link_ref" href="https://myndir.uvic.ca/">My Norse Digital Image Repository</a></td>
-                     
                      <td><a class="link_ref" href="https://myndir.uvic.ca/search.html">Search</a></td>
-                     
                      <td><a class="link_ref" href="https://hcmc.uvic.ca/svn/myndir/config_staticSearch.xml">SVN</a></td>
-                     </tr>
-                  
+                  </tr>
                   <tr>
-                     
                      <td><a class="link_ref" href="https://bcgenesis.uvic.ca/">The Colonial Despatches of BC and Vancouver Island</a></td>
-                     
                      <td><a class="link_ref" href="https://bcgenesis.uvic.ca/search.html">Search</a></td>
-                     
                      <td><a class="link_ref" href="https://hcmc.uvic.ca/svn/coldesp/trunk/config_staticSearch.xml">SVN</a></td>
-                     </tr>
-                  
+                  </tr>
                   <tr>
-                     
                      <td><a class="link_ref" href="https://graves.uvic.ca/">The Robert Graves Diary</a></td>
-                     
                      <td><a class="link_ref" href="https://graves.uvic.ca/search.html">Search</a></td>
-                     
                      <td><a class="link_ref" href="https://hcmc.uvic.ca/svn/graves/config_staticSearch.xml">SVN</a></td>
-                     </tr>
-                  
+                  </tr>
                   <tr>
-                     
                      <td><a class="link_ref" href="https://francotoile.uvic.ca/">Francotoile</a> ( a digital library of videos and transcripts of French speakers from around the
                         world)</td>
-                     
                      <td><a class="link_ref" href="https://francotoile.uvic.ca/search.html">Search</a></td>
-                     
                      <td><a class="link_ref" href="https://hcmc.uvic.ca/svn/francotoile/trunk/config_staticSearch.xml">SVN</a></td>
-                     </tr>
-                  
+                  </tr>
                   <tr>
-                     
                      <td><a class="link_ref" href="https://dvpp.uvic.ca">Digital Victorian Periodical Poetry</a></td>
-                     
                      <td><a class="link_ref" href="https://dvpp.uvic.ca/search.html">Search</a> (multiple searches with individual pages)</td>
-                     
                      <td><a class="link_ref" href="https://hcmc.uvic.ca/svn/dvpp/">SVN</a> (multiple configuration files)</td>
-                     </tr>
-                  
+                  </tr>
                   <tr>
-                     
                      <td><a class="link_ref" href="https://mariage.uvic.ca/">Le mariage sous L'Ancien Régime</a></td>
-                     
                      <td><a class="link_ref" href="https://mariage.uvic.ca/recherche.html">Recherche</a></td>
-                     
                      <td><a class="link_ref" href="https://hcmc.uvic.ca/svn/mariage/static/config_staticSearch.xml">SVN</a></td>
-                     </tr>
-                  
+                  </tr>
                   <tr>
-                     
                      <td><a class="link_ref" href="https://loi.uvic.ca/archive/">Landscapes of Injustice</a></td>
-                     
                      <td><a class="link_ref" href="https://loi.uvic.ca/archive/search.html">Search</a>. The home page is itself a search page; this is a digital archive with multiple staticSearch
                         interfaces.</td>
-                     
                      <td><a class="link_ref" href="https://hcmc.uvic.ca/svn/landscapes/production/">SVN</a></td>
-                     </tr>
-                  
+                  </tr>
                   <tr>
-                     
                      <td><a class="link_ref" href="http://medievalmideast.org/">Historical Index of the Medieval Middle East</a></td>
-                     
                      <td>The home page includes a search function which leads to the search page.</td>
-                     
                      <td></td>
-                     </tr>
-                  
+                  </tr>
                   <tr>
-                     
                      <td><a class="link_ref" href="https://lemdo.uvic.ca/moms/">The MoEML Mayoral Shows Anthology (hosted by Linked Early Modern Drama Online)</a></td>
-                     
                      <td><a class="link_ref" href="https://lemdo.uvic.ca/moms/search.html">Search</a></td>
-                     
                      <td><a class="link_ref" href="https://hcmc.uvic.ca/svn/lemdo/data/anthologies/moms/config_staticSearch.xml">SVN</a></td>
-                     </tr>
-                  </table>
-               </div>
-            </section>
-         </div>
+                  </tr>
+               </table>
+            </div>
+         </section>
+      </div>
       <!--TEI back-->
-      
       <div class="tei_back">
-         
          <section class="teidiv0" id="schemaSpec">
-            
             <header>
-               
                <h2><span class="headingNumber">Appendix A </span><span class="head">Schema specification and tag documentation</span></h2>
-               </header>
-            
+            </header>
             <div class="teidiv1" id="index.xml-back.1_div.1_div.1">
-               
                <h3><span class="headingNumber">Appendix A.1 </span><span class="head">Elements</span></h3>
-               
                <div class="refdoc" id="TEI.config">
-                  
                   <h3><span class="headingNumber">Appendix A.1.1 </span><span class="head">&lt;config&gt;</span></h3>
-                  
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;config&gt; </span>(<span>The root element for the Search Generator configuration file.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Attributes</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="table">
-                                 
                                  <table class="attList">
-                                    
                                     <tr>
-                                       
                                        <td class="odd_label">version</td>
-                                       
                                        <td class="odd_value">(<span>specifies the major version of staticSearch to which this configuration file corresponds.
                                              If this attribute is not used, the configuration file is assumed to have an version
                                              value of 1.</span>) 
-                                          
                                           <div class="table">
-                                             
                                              <table class="attDef">
-                                                
                                                 <tr>
-                                                   
                                                    <td class="odd_label"><span xml:lang="en" lang="en" class="label">Status</span></td>
-                                                   
                                                    <td class="odd_value"><span xml:lang="en" lang="en">Recommended</span></td>
-                                                   </tr>
-                                                
+                                                </tr>
                                                 <tr>
-                                                   
                                                    <td class="odd_label"><span xml:lang="en" lang="en" class="label">Datatype</span></td>
-                                                   
                                                    <td class="odd_value"><a class="link_ref" href="https://www.w3.org/TR/xmlschema-2/#nonNegativeInteger">nonNegativeInteger</a></td>
-                                                   </tr>
-                                                
+                                                </tr>
                                                 <tr>
-                                                   
                                                    <td class="odd_label"><span xml:lang="en" lang="en" class="label">Default</span></td>
-                                                   
                                                    <td class="odd_value">1</td>
-                                                   </tr>
-                                                
+                                                </tr>
                                                 <tr>
-                                                   
                                                    <td colspan="2">
-                                                      
                                                       <div id="index.xml-egXML-d38e2243" class="pre egXML_valid"><span class="element">&lt;config <span class="attribute">version</span>="<span class="attributevalue">1</span>"&gt;</span><br/> <span class="element">&lt;params&gt;</span><br/><span class="comment">&lt;!--Config options--&gt;</span><br/> <span class="element">&lt;/params&gt;</span><br/><span class="element">&lt;/config&gt;</span></div>
-                                                      </td>
-                                                   </tr>
-                                                
+                                                   </td>
+                                                </tr>
                                                 <tr>
-                                                   
                                                    <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
-                                                   
                                                    <td class="wovenodd-col2">
-                                                      
                                                       <p>The <span class="att">version</span> attribute only needs to specify the major version of staticSearch with which the
                                                          configuration file is compatible. While minor versions may introduce new, optional
                                                          configuration options, backwards-incompatible changes to the config will only occur
                                                          across major versions (e.g. a configuration file created for staticSearch 1.1 will
                                                          work with staticSearch 1.4, but is not guaranteed to work with staticSearch 2.0).</p>
-                                                      </td>
-                                                   </tr>
-                                                </table>
-                                             </div>
-                                          </td>
-                                       </tr>
-                                    </table>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                                                   </td>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                 </table>
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">—</div>
-                              </td>
-                           </tr>
-                        
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="specChildren">
-                                 
-                                 <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.contexts" title="&lt;contexts&gt;">contexts</a> <a class="link_odd_elementSpec" href="#TEI.excludes" title="&lt;excludes&gt;">excludes</a> <a class="link_odd_elementSpec" href="#TEI.params" title="&lt;params&gt;">params</a> <a class="link_odd_elementSpec" href="#TEI.rules" title="&lt;rules&gt;">rules</a></span></div>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                                 <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.contexts" title="&lt;contexts&gt;">contexts</a> <a class="link_odd_elementSpec" href="#TEI.excludes" title="&lt;excludes&gt;">excludes</a> <a class="link_odd_elementSpec" href="#TEI.filters" title="&lt;filters&gt;">filters</a> <a class="link_odd_elementSpec" href="#TEI.params" title="&lt;params&gt;">params</a> <a class="link_odd_elementSpec" href="#TEI.rules" title="&lt;rules&gt;">rules</a></span></div>
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e2294" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e2298" class="pre_eg cdata">
 &lt;content&gt;
  &lt;elementRef key="params"/&gt;
  &lt;elementRef key="rules" minOccurs="0"/&gt;
  &lt;elementRef key="contexts" minOccurs="0"/&gt;
  &lt;elementRef key="excludes" minOccurs="0"/&gt;
+ &lt;elementRef key="filters" minOccurs="0"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e2294" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e2298" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e2301" class="pre_eg">
+                              <pre id="index.xml-eg-d38e2305" class="pre_eg">
 element config
 {
    attribute version { text }?,
    <a class="link_ref" href="#TEI.params" title="&lt;params&gt;">params</a>,
    <a class="link_ref" href="#TEI.rules" title="&lt;rules&gt;">rules</a>?,
    <a class="link_ref" href="#TEI.contexts" title="&lt;contexts&gt;">contexts</a>?,
-   <a class="link_ref" href="#TEI.excludes" title="&lt;excludes&gt;">excludes</a>?
-}<a href="#index.xml-eg-d38e2301" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+   <a class="link_ref" href="#TEI.excludes" title="&lt;excludes&gt;">excludes</a>?,
+   <a class="link_ref" href="#TEI.filters" title="&lt;filters&gt;">filters</a>?
+}<a href="#index.xml-eg-d38e2305" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.context">
-                  
                   <h3><span class="headingNumber">Appendix A.1.2 </span><span class="head">&lt;context&gt;</span></h3>
-                  
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;context&gt; </span>(<span>A context definition, providing a match attribute that identifies the context, allowing
                                  keyword-in-context fragments to be bounded by a specific context.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Attributes</span></td>
-                           
                            <td class="wovenodd-col2"><a class="link_ref" href="#TEI.att.match" title="att.match">att.match</a> (<span class="attribute">@match</span>) <a class="link_ref" href="#TEI.att.labelled" title="att.labelled">att.labelled</a> (<span class="attribute">@label</span>) 
-                              
                               <div class="table">
-                                 
                                  <table class="attList">
-                                    
                                     <tr>
-                                       
                                        <td class="odd_label">context</td>
-                                       
                                        <td class="odd_value">
-                                          
                                           <div class="table">
-                                             
                                              <table class="attDef">
-                                                
                                                 <tr>
-                                                   
                                                    <td class="odd_label"><span xml:lang="en" lang="en" class="label">Status</span></td>
-                                                   
                                                    <td class="odd_value"><span xml:lang="en" lang="en">Optional</span></td>
-                                                   </tr>
-                                                
+                                                </tr>
                                                 <tr>
-                                                   
                                                    <td class="odd_label"><span xml:lang="en" lang="en" class="label">Datatype</span></td>
-                                                   
                                                    <td class="odd_value"><a class="link_ref" href="https://www.w3.org/TR/xmlschema-2/#boolean">boolean</a></td>
-                                                   </tr>
-                                                </table>
-                                             </div>
-                                          </td>
-                                       </tr>
-                                    </table>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                 </table>
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.contexts" title="&lt;contexts&gt;">contexts</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2"><span xml:lang="en" lang="en">Empty element</span></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <p>When the indexer is extracting keyword-in-context strings for each word, it uses a
                                  common-sense approach based on common element definitions, so that for example when
                                  it reaches the end of a paragraph, it will not continue into the next paragraph to
@@ -2599,291 +1758,189 @@ element config
                                  which do not appear to be bounding contexts, but actually are; for example, you may
                                  have span elements with <span class="att">class</span>=<span class="val">note</span> that appear in the middle of sentences but are not actually part of them. Use <a class="link_ref" href="#TEI.context" title="&lt;context&gt;">&lt;context&gt;</a> elements to identify these special contexts so that the indexer knows the right boundaries
                                  from which to retrieve its keyword-in-context strings.</p>
-                              </td>
-                           </tr>
-                        
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e2430" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e2437" class="pre_eg cdata">
 &lt;content&gt;
  &lt;empty/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e2430" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e2437" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e2437" class="pre_eg">
+                              <pre id="index.xml-eg-d38e2444" class="pre_eg">
 element context
 {
    <a class="link_ref" href="#TEI.att.match" title="att.match">att.match.attributes</a>,
    <a class="link_ref" href="#TEI.att.labelled" title="att.labelled">att.labelled.attributes</a>,
    attribute context { text }?,
    empty
-}<a href="#index.xml-eg-d38e2437" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+}<a href="#index.xml-eg-d38e2444" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.contexts">
-                  
                   <h3><span class="headingNumber">Appendix A.1.3 </span><span class="head">&lt;contexts&gt;</span></h3>
-                  
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;contexts&gt; </span>(<span>The set of context elements that identify contexts for keyword-in-context fragments.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.config" title="&lt;config&gt;">config</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="specChildren">
-                                 
                                  <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.context" title="&lt;context&gt;">context</a></span></div>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e2502" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e2509" class="pre_eg cdata">
 &lt;content&gt;
  &lt;elementRef key="context" minOccurs="1"
   maxOccurs="unbounded"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e2502" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e2509" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e2509" class="pre_eg">
-element contexts { <a class="link_ref" href="#TEI.context" title="&lt;context&gt;">context</a>+ }<a href="#index.xml-eg-d38e2509" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                              <pre id="index.xml-eg-d38e2516" class="pre_eg">
+element contexts { <a class="link_ref" href="#TEI.context" title="&lt;context&gt;">context</a>+ }<a href="#index.xml-eg-d38e2516" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.createContexts">
-                  
                   <h3><span class="headingNumber">Appendix A.1.4 </span><span class="head">&lt;createContexts&gt;</span></h3>
-                  
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;createContexts&gt; </span>(<span>Whether to include keyword-in-context extracts in the index.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.params" title="&lt;params&gt;">params</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="specChildren">
-                                 
                                  <div class="specChild">XSD boolean</div>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <p><a class="link_ref" href="#TEI.createContexts" title="&lt;createContexts&gt;">&lt;createContexts&gt;</a> is a boolean parameter that specifies whether you want the indexer to store keyword-in-context
                                  extracts for each of the hits in a document. This increases the size of the index,
                                  but of course it makes for much more user-friendly search results; instead of seeing
                                  just a score for each document found, the user will see a series of short text strings
                                  with the search keyword(s) highlighted.</p>
-                              
                               <p>Note that contexts are necessary for phrasal searching or wildcard searching.</p>
-                              </td>
-                           </tr>
-                        
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e2578" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e2585" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="boolean"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e2578" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e2585" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e2585" class="pre_eg cdata">
-element createContexts { xsd:boolean }<a href="#index.xml-eg-d38e2585" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                              <pre id="index.xml-eg-d38e2592" class="pre_eg cdata">
+element createContexts { xsd:boolean }<a href="#index.xml-eg-d38e2592" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.dictionaryFile">
-                  
                   <h3><span class="headingNumber">Appendix A.1.5 </span><span class="head">&lt;dictionaryFile&gt;</span></h3>
-                  
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;dictionaryFile&gt; </span>(<span>The relative path (from the config file) to a dictionary file (one word per line)
                                  which will be used to check tokens when indexing.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.params" title="&lt;params&gt;">params</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="specChildren">
-                                 
                                  <div class="specChild">XSD anyURI</div>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <p>The indexing process checks each word as it builds the index, and keeps a record of
                                  all words which are not found in the configured dictionary. Though this does not have
                                  any direct effect in the indexing process, all words not found in the dictionary are
@@ -2891,930 +1948,824 @@ element createContexts { xsd:boolean }<a href="#index.xml-eg-d38e2585" class="an
                                  of the dictionary) or perhaps misspelled (in which case they may not be correctly
                                  stemmed and index, and should be corrected). There is a default dictionary in <span class="ident">xsl/english_words.txt</span> which you might copy and adapt if you're working in English; lots of dictionaries
                                  for other languages are available on the Web.</p>
-                              </td>
-                           </tr>
-                        
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e2652" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e2659" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="anyURI"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e2652" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e2659" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e2659" class="pre_eg cdata">
-element dictionaryFile { xsd:anyURI }<a href="#index.xml-eg-d38e2659" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                              <pre id="index.xml-eg-d38e2666" class="pre_eg cdata">
+element dictionaryFile { xsd:anyURI }<a href="#index.xml-eg-d38e2666" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.exclude">
-                  
                   <h3><span class="headingNumber">Appendix A.1.6 </span><span class="head">&lt;exclude&gt;</span></h3>
-                  
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;exclude&gt; </span>(<span>An exclusion definition, which excludes either documents or filters as defined by
                                  an XPath in the match attribute.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Attributes</span></td>
-                           
                            <td class="wovenodd-col2"><a class="link_ref" href="#TEI.att.match" title="att.match">att.match</a> (<span class="attribute">@match</span>) 
-                              
                               <div class="table">
-                                 
                                  <table class="attList">
-                                    
                                     <tr>
-                                       
                                        <td class="odd_label">type</td>
-                                       
                                        <td class="odd_value">
-                                          
                                           <div class="table">
-                                             
                                              <table class="attDef">
-                                                
                                                 <tr>
-                                                   
                                                    <td class="odd_label"><span xml:lang="en" lang="en" class="label">Status</span></td>
-                                                   
                                                    <td class="odd_value"><span xml:lang="en" lang="en"><span class="required">Required</span></span></td>
-                                                   </tr>
-                                                
+                                                </tr>
                                                 <tr>
-                                                   
                                                    <td class="odd_label"><span xml:lang="en" lang="en" class="label">Legal values are:</span></td>
-                                                   
                                                    <td class="odd_value">
-                                                      
                                                       <dl class="valList">
-                                                         
                                                          <dt><span class="odd_label">index</span></dt>
-                                                         
                                                          <dd>(<span>Index exclusion</span>) <span>An exclusion that specifies HTML fragment (which itself can be the root HTML element)
                                                                to exclude from the document index.</span></dd>
-                                                         
                                                          <dt><span class="odd_label">filter</span></dt>
-                                                         
                                                          <dd>(<span>Filter exclusion</span>) <span>An exclusion that matches an HTML meta tag to exclude from the filter controls on
                                                                the search page.</span></dd>
-                                                         </dl>
-                                                      </td>
-                                                   </tr>
-                                                </table>
-                                             </div>
-                                          </td>
-                                       </tr>
-                                    </table>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                                                      </dl>
+                                                   </td>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                 </table>
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.excludes" title="&lt;excludes&gt;">excludes</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2"><span xml:lang="en" lang="en">Empty element</span></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <p><a class="link_ref" href="#TEI.exclude" title="&lt;exclude&gt;">&lt;exclude&gt;</a> can be used to identify documents or parts of documents that are to be omitted from
                                  indexing, but, unlike setting <span class="gi">&lt;weight&gt;</span> to zero, should be retained during the indexing process. This is helpful in cases
                                  where the text itself should be ignored by the indexer, but should still appear in
                                  KWICs. Another common use is for multiple search engines/pages that each have their
                                  own special features; in this case, you may want one specific search index/page to
                                  ignore filter controls (HTML <span class="gi">&lt;meta&gt;</span> elements, as described in <a class="link_ptr" href="#searchFacetFeatures" title="Search facet features"><span class="headingNumber">5 </span>Search facet features</a>) which are provided to support other search pages.</p>
-                              </td>
-                           </tr>
-                        
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e2780" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e2787" class="pre_eg cdata">
 &lt;content&gt;
  &lt;empty/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e2780" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e2787" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e2787" class="pre_eg">
+                              <pre id="index.xml-eg-d38e2794" class="pre_eg">
 element exclude
 {
    <a class="link_ref" href="#TEI.att.match" title="att.match">att.match.attributes</a>,
    attribute type { "index" | "filter" },
    empty
-}<a href="#index.xml-eg-d38e2787" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+}<a href="#index.xml-eg-d38e2794" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.excludes">
-                  
                   <h3><span class="headingNumber">Appendix A.1.7 </span><span class="head">&lt;excludes&gt;</span></h3>
-                  
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;excludes&gt; </span>(<span>The set of exclusions, expressed as exclude elements, that control the subset of documents
                                  or filters used for a particular search.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.config" title="&lt;config&gt;">config</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="specChildren">
-                                 
                                  <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.exclude" title="&lt;exclude&gt;">exclude</a></span></div>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e2849" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e2856" class="pre_eg cdata">
 &lt;content&gt;
  &lt;elementRef key="exclude" minOccurs="1"
   maxOccurs="unbounded"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e2849" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e2856" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e2856" class="pre_eg">
-element excludes { <a class="link_ref" href="#TEI.exclude" title="&lt;exclude&gt;">exclude</a>+ }<a href="#index.xml-eg-d38e2856" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                              <pre id="index.xml-eg-d38e2863" class="pre_eg">
+element excludes { <a class="link_ref" href="#TEI.exclude" title="&lt;exclude&gt;">exclude</a>+ }<a href="#index.xml-eg-d38e2863" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
-               <div class="refdoc" id="TEI.kwicTruncateString">
-                  
-                  <h3><span class="headingNumber">Appendix A.1.8 </span><span class="head">&lt;kwicTruncateString&gt;</span></h3>
-                  
+               </div>
+               <div class="refdoc" id="TEI.filter">
+                  <h3><span class="headingNumber">Appendix A.1.8 </span><span class="head">&lt;filter&gt;</span></h3>
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
+                           <td colspan="2" class="wovenodd-col2"><span class="label">&lt;filter&gt; </span>(<span>Allows specification of a custom label for a filter on the search page</span>) <span>Filters are identified through plain-text labels defined as XHTML meta/@name attributes
+                                 in the document headers. This element allows a user to specify a richer label for
+                                 a particular filter by using HTML code. Multiple labels may be specified in different
+                                 languages. The <span class="att">filterName</span> attribute must be supplied, and must be identical to the XHTML meta/@name attribute
+                                 for the filter as it appears in the HTML document heads.</span></td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
+                           <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
+                           <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Attributes</span></td>
+                           <td class="wovenodd-col2">
+                              <div class="table">
+                                 <table class="attList">
+                                    <tr>
+                                       <td class="odd_label">filterName</td>
+                                       <td class="odd_value">
+                                          <div class="table">
+                                             <table class="attDef">
+                                                <tr>
+                                                   <td class="odd_label"><span xml:lang="en" lang="en" class="label">Status</span></td>
+                                                   <td class="odd_value"><span xml:lang="en" lang="en"><span class="required">Required</span></span></td>
+                                                </tr>
+                                                <tr>
+                                                   <td class="odd_label"><span xml:lang="en" lang="en" class="label">Datatype</span></td>
+                                                   <td class="odd_value">teidata.text</td>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                 </table>
+                              </div>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
+                           <td class="wovenodd-col2">
+                              <div class="parent">
+                                 <div class="specChildren">
+                                    <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.filters" title="&lt;filters&gt;">filters</a></span></div>
+                                 </div>
+                              </div>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
+                           <td class="wovenodd-col2">
+                              <div class="specChildren">
+                                 <div class="specChild"><span class="specChildModule">ssHTML: </span><span class="specChildElements">label</span></div>
+                              </div>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
+                           <td class="wovenodd-col2">
+                              <pre id="index.xml-eg-d38e2961" class="pre_eg cdata">
+&lt;content&gt;
+ &lt;elementRef key="label" minOccurs="1"
+  maxOccurs="unbounded"/&gt;
+&lt;/content&gt;
+    <a href="#index.xml-eg-d38e2961" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
+                           <td class="wovenodd-col2">
+                              <pre id="index.xml-eg-d38e2968" class="pre_eg">
+element filter { attribute filterName { text }, label+ }<a href="#index.xml-eg-d38e2968" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
+                  </div>
+               </div>
+               <div class="refdoc" id="TEI.filters">
+                  <h3><span class="headingNumber">Appendix A.1.9 </span><span class="head">&lt;filters&gt;</span></h3>
+                  <div class="table">
+                     <table class="wovenodd">
+                        <tr>
+                           <td colspan="2" class="wovenodd-col2"><span class="label">&lt;filters&gt; </span>(<span>Wrapper for filter elements in the configuration file</span>) <span>The optional filters/filter part of the configuration file allows the user to specify
+                                 custom labels with HTML markup for specific filters, so they are not limited by the
+                                 label supplied in the XHTML meta/@name attribute.</span></td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
+                           <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
+                           <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
+                           <td class="wovenodd-col2">
+                              <div class="parent">
+                                 <div class="specChildren">
+                                    <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.config" title="&lt;config&gt;">config</a></span></div>
+                                 </div>
+                              </div>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
+                           <td class="wovenodd-col2">
+                              <div class="specChildren">
+                                 <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.filter" title="&lt;filter&gt;">filter</a></span></div>
+                              </div>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
+                           <td class="wovenodd-col2">
+                              <pre id="index.xml-eg-d38e3031" class="pre_eg cdata">
+&lt;content&gt;
+ &lt;elementRef key="filter" minOccurs="1"
+  maxOccurs="unbounded"/&gt;
+&lt;/content&gt;
+    <a href="#index.xml-eg-d38e3031" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
+                           <td class="wovenodd-col2">
+                              <pre id="index.xml-eg-d38e3038" class="pre_eg">
+element filters { <a class="link_ref" href="#TEI.filter" title="&lt;filter&gt;">filter</a>+ }<a href="#index.xml-eg-d38e3038" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
+                  </div>
+               </div>
+               <div class="refdoc" id="TEI.kwicTruncateString">
+                  <h3><span class="headingNumber">Appendix A.1.10 </span><span class="head">&lt;kwicTruncateString&gt;</span></h3>
+                  <div class="table">
+                     <table class="wovenodd">
+                        <tr>
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;kwicTruncateString&gt; </span>(<span>The string that will be used to signal ellipsis at the beginning and end of a keyword-in-context
                                  extract. Conventionally three periods, or an ellipsis character (which is the default
                                  value).</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.params" title="&lt;params&gt;">params</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2"><span xml:lang="en" lang="en">Character data only</span></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <p>The only reason you might need to specify a value for this parameter is if the language
                                  of your search page conventionally uses a different ellipsis character. Japanese,
                                  for example, uses the 3-dot-leader character.</p>
-                              </td>
-                           </tr>
-                        
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e2920" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e3102" class="pre_eg cdata">
 &lt;content&gt;
  &lt;textNode/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e2920" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e3102" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e2927" class="pre_eg cdata">
-element kwicTruncateString { text }<a href="#index.xml-eg-d38e2927" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                              <pre id="index.xml-eg-d38e3109" class="pre_eg cdata">
+element kwicTruncateString { text }<a href="#index.xml-eg-d38e3109" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
-               <div class="refdoc" id="TEI.linkToFragmentId">
-                  
-                  <h3><span class="headingNumber">Appendix A.1.9 </span><span class="head">&lt;linkToFragmentId&gt;</span></h3>
-                  
+               </div>
+               <div class="refdoc" id="TEI.xh_label">
+                  <h3><span class="headingNumber">Appendix A.1.11 </span><span class="head">&lt;label&gt;</span></h3>
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
+                           <td colspan="2" class="wovenodd-col2"><span class="label">&lt;label&gt; </span>(<span>An HTML label</span>) <span>A standard HTML label element, within which other HTML content can be included. We
+                                 do not prescribe or validate the content model; see e.g. https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label
+                                 for information.</span></td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
+                           <td class="wovenodd-col2">http://www.w3.org/1999/xhtml</td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
+                           <td class="wovenodd-col2">ssHTML — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Attributes</span></td>
+                           <td class="wovenodd-col2">
+                              <div class="table">
+                                 <table class="attList">
+                                    <tr>
+                                       <td class="odd_label">lang</td>
+                                       <td class="odd_value">(<span>The language of this label</span>) <span>Multiple labels may be supplied in different languages if required. The value of this
+                                             attribute should be a valid language identifier per BCP 47.</span><div class="table">
+                                             <table class="attDef">
+                                                <tr>
+                                                   <td class="odd_label"><span xml:lang="en" lang="en" class="label">Status</span></td>
+                                                   <td class="odd_value"><span xml:lang="en" lang="en">Recommended</span></td>
+                                                </tr>
+                                                <tr>
+                                                   <td class="odd_label"><span xml:lang="en" lang="en" class="label">Datatype</span></td>
+                                                   <td class="odd_value">teidata.language</td>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                 </table>
+                              </div>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
+                           <td class="wovenodd-col2">
+                              <div class="parent">
+                                 <div class="specChildren">
+                                    <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.filter" title="&lt;filter&gt;">filter</a></span></div>
+                                 </div>
+                              </div>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
+                           <td class="wovenodd-col2"><span xml:lang="en" lang="en">ANY</span></td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
+                           <td class="wovenodd-col2">
+                              <pre id="index.xml-eg-d38e3199" class="pre_eg cdata">
+&lt;content&gt;
+ &lt;alternate minOccurs="1"
+  maxOccurs="unbounded"&gt;
+  &lt;anyElement require="http://www.w3.org/1999/xhtml"
+   minOccurs="0" maxOccurs="unbounded"/&gt;
+  &lt;textNode/&gt;
+ &lt;/alternate&gt;
+&lt;/content&gt;
+    <a href="#index.xml-eg-d38e3199" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                        <tr>
+                           <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
+                           <td class="wovenodd-col2">
+                              <pre id="index.xml-eg-d38e3206" class="pre_eg">
+element label { attribute lang { text }?, ( anyElement-label* | text )+ }<a href="#index.xml-eg-d38e3206" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
+                  </div>
+               </div>
+               <div class="refdoc" id="TEI.linkToFragmentId">
+                  <h3><span class="headingNumber">Appendix A.1.12 </span><span class="head">&lt;linkToFragmentId&gt;</span></h3>
+                  <div class="table">
+                     <table class="wovenodd">
+                        <tr>
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;linkToFragmentId&gt; </span>(<span>Whether to link keyword-in-context extracts to the nearest id in the document. Default
                                  is true.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">—</div>
-                              </td>
-                           </tr>
-                        
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="specChildren">
-                                 
                                  <div class="specChild">XSD boolean</div>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <p><a class="link_ref" href="#TEI.linkToFragmentId" title="&lt;linkToFragmentId&gt;">&lt;linkToFragmentId&gt;</a> is a boolean parameter that specifies whether you want the search engine to link
                                  each keyword-in-context extract with the closest element that has an <span class="att">id</span>. If the element has an ancestor with an <span class="att">id</span>, then the indexer will associate that keyword-in-context extract with that <span class="att">id</span>; if there are no suitable ancestor elements that have an <span class="att">id</span>, then the extract is associated with first preceding element with an <span class="att">id</span>.</p>
-                              
                               <p>We strongly recommend that you ensure your target documents have id attributes for
                                  any significant divisions so that this parameter can be used effectively. With lots
                                  of ids throughout your documents, and this parameter turned on, each keyword-in-context
                                  in the results page will be linked directly to the section of the document in which
                                  the hit appears, making the search results much more useful.</p>
-                              </td>
-                           </tr>
-                        
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e3002" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e3284" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="boolean"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e3002" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e3284" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e3009" class="pre_eg cdata">
-element linkToFragmentId { xsd:boolean }<a href="#index.xml-eg-d38e3009" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                              <pre id="index.xml-eg-d38e3291" class="pre_eg cdata">
+element linkToFragmentId { xsd:boolean }<a href="#index.xml-eg-d38e3291" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.maxKwicsToHarvest">
-                  
-                  <h3><span class="headingNumber">Appendix A.1.10 </span><span class="head">&lt;maxKwicsToHarvest&gt;</span></h3>
-                  
+                  <h3><span class="headingNumber">Appendix A.1.13 </span><span class="head">&lt;maxKwicsToHarvest&gt;</span></h3>
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;maxKwicsToHarvest&gt; </span>(<span>This controls the maximum number of keyword-in-context extracts that will be stored
                                  for each term in a document.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.params" title="&lt;params&gt;">params</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="specChildren">
-                                 
                                  <div class="specChild">XSD nonNegativeInteger</div>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <p><a class="link_ref" href="#TEI.maxKwicsToHarvest" title="&lt;maxKwicsToHarvest&gt;">&lt;maxKwicsToHarvest&gt;</a> controls the number of keyword-in-context extracts that will be harvested from the
                                  data for each term in a document. For example, if a user searches for the word <span class="q">‘elephant’</span>, and it occurs 27 times in a document, but the <a class="link_ref" href="#TEI.maxKwicsToHarvest" title="&lt;maxKwicsToHarvest&gt;">&lt;maxKwicsToHarvest&gt;</a> value is set to 5, then only the first five (sorted in document order) of these keyword-in-context
                                  strings will be stored in the index. (This does not affect the score of the document
                                  in the search results, of course.) If you set this to a low number, the size of the
                                  JSON files will be constrained, but of course the user will only be able to see the
                                  KWICs that have been harvested in their search results.</p>
-                              
                               <p>If <a class="link_ref" href="#TEI.phrasalSearch" title="&lt;phrasalSearch&gt;">&lt;phrasalSearch&gt;</a> is set to true, the <a class="link_ref" href="#TEI.maxKwicsToHarvest" title="&lt;maxKwicsToHarvest&gt;">&lt;maxKwicsToHarvest&gt;</a> setting is ignored, because phrasal searches will only work properly if all contexts
                                  are stored.</p>
-                              </td>
-                           </tr>
-                        
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e3087" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e3369" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="nonNegativeInteger"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e3087" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e3369" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e3094" class="pre_eg cdata">
-element maxKwicsToHarvest { xsd:nonNegativeInteger }<a href="#index.xml-eg-d38e3094" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                              <pre id="index.xml-eg-d38e3376" class="pre_eg cdata">
+element maxKwicsToHarvest { xsd:nonNegativeInteger }<a href="#index.xml-eg-d38e3376" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.maxKwicsToShow">
-                  
-                  <h3><span class="headingNumber">Appendix A.1.11 </span><span class="head">&lt;maxKwicsToShow&gt;</span></h3>
-                  
+                  <h3><span class="headingNumber">Appendix A.1.14 </span><span class="head">&lt;maxKwicsToShow&gt;</span></h3>
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;maxKwicsToShow&gt; </span>(<span>This controls the maximum number of keyword-in-context extracts that will be shown
                                  in the search page for each hit document returned.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.params" title="&lt;params&gt;">params</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="specChildren">
-                                 
                                  <div class="specChild">XSD nonNegativeInteger</div>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <p>A user may search for multiple common words, so hundreds of hits could be found in
                                  a single document. If the keyword-in-context strings for all these hits are shown
                                  on the results page, it would be too long and too difficult to navigate. This setting
                                  controls how many of those hits you want to show for each document in the result set.</p>
-                              </td>
-                           </tr>
-                        
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e3157" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e3438" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="nonNegativeInteger"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e3157" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e3438" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e3164" class="pre_eg cdata">
-element maxKwicsToShow { xsd:nonNegativeInteger }<a href="#index.xml-eg-d38e3164" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                              <pre id="index.xml-eg-d38e3445" class="pre_eg cdata">
+element maxKwicsToShow { xsd:nonNegativeInteger }<a href="#index.xml-eg-d38e3445" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.minWordLength">
-                  
-                  <h3><span class="headingNumber">Appendix A.1.12 </span><span class="head">&lt;minWordLength&gt;</span></h3>
-                  
+                  <h3><span class="headingNumber">Appendix A.1.15 </span><span class="head">&lt;minWordLength&gt;</span></h3>
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;minWordLength&gt; </span>(<span>The minimum length of a term to be indexed. Default is 3 characters.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.params" title="&lt;params&gt;">params</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="specChildren">
-                                 
                                  <div class="specChild">XSD nonNegativeInteger</div>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <p><a class="link_ref" href="#TEI.minWordLength" title="&lt;minWordLength&gt;">&lt;minWordLength&gt;</a> specifies the minimum length in characters of a sequence of text that will be considered
                                  to be a word worth indexing. The default is 3, on the basis that in most European
                                  languages, words of one or two letters are typically not worth indexing, being articles,
                                  prepositions and so on. If you set this to a lower limit for reasons specific to your
                                  project, you should ensure that your stopword list excludes any very common words
                                  that would otherwise make the indexing process lengthy and increase the index size.</p>
-                              </td>
-                           </tr>
-                        
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e3229" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e3510" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="nonNegativeInteger"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e3229" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e3510" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e3236" class="pre_eg cdata">
-element minWordLength { xsd:nonNegativeInteger }<a href="#index.xml-eg-d38e3236" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                              <pre id="index.xml-eg-d38e3517" class="pre_eg cdata">
+element minWordLength { xsd:nonNegativeInteger }<a href="#index.xml-eg-d38e3517" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.outputFolder">
-                  
-                  <h3><span class="headingNumber">Appendix A.1.13 </span><span class="head">&lt;outputFolder&gt;</span></h3>
-                  
+                  <h3><span class="headingNumber">Appendix A.1.16 </span><span class="head">&lt;outputFolder&gt;</span></h3>
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;outputFolder&gt; </span>(<span>The name of the output folder into which the index data and JavaScript will be placed
                                  in the site search. This should conform with the XML Name specification.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.params" title="&lt;params&gt;">params</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="specChildren">
-                                 
                                  <div class="specChild">XSD NCName</div>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <p>When the staticSearch build process creates its output, many files need to be added
                                  to the website for which an index is being created. For convenience, all of these
                                  files are stored in a single folder. This element is used to specify the name of that
                                  folder. The default is <span class="val">staticSearch</span>, but if you would prefer something else, you can specify it here. You may also use
                                  this element if you are defining two different searches within the same site, so that
                                  their files are kept in different locations.</p>
-                              </td>
-                           </tr>
-                        
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e3302" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e3583" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="NCName"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e3302" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e3583" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e3309" class="pre_eg cdata">
-element outputFolder { xsd:NCName }<a href="#index.xml-eg-d38e3309" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                              <pre id="index.xml-eg-d38e3590" class="pre_eg cdata">
+element outputFolder { xsd:NCName }<a href="#index.xml-eg-d38e3590" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.params">
-                  
-                  <h3><span class="headingNumber">Appendix A.1.14 </span><span class="head">&lt;params&gt;</span></h3>
-                  
+                  <h3><span class="headingNumber">Appendix A.1.17 </span><span class="head">&lt;params&gt;</span></h3>
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;params&gt; </span>(<span>Element containing most of the settings which enable the Generator to find the target
                                  website content and process it appropriately.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.config" title="&lt;config&gt;">config</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="specChildren">
-                                 
                                  <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.createContexts" title="&lt;createContexts&gt;">createContexts</a> <a class="link_odd_elementSpec" href="#TEI.dictionaryFile" title="&lt;dictionaryFile&gt;">dictionaryFile</a> <a class="link_odd_elementSpec" href="#TEI.kwicTruncateString" title="&lt;kwicTruncateString&gt;">kwicTruncateString</a> <a class="link_odd_elementSpec" href="#TEI.maxKwicsToHarvest" title="&lt;maxKwicsToHarvest&gt;">maxKwicsToHarvest</a> <a class="link_odd_elementSpec" href="#TEI.maxKwicsToShow" title="&lt;maxKwicsToShow&gt;">maxKwicsToShow</a> <a class="link_odd_elementSpec" href="#TEI.minWordLength" title="&lt;minWordLength&gt;">minWordLength</a> <a class="link_odd_elementSpec" href="#TEI.outputFolder" title="&lt;outputFolder&gt;">outputFolder</a> <a class="link_odd_elementSpec" href="#TEI.phrasalSearch" title="&lt;phrasalSearch&gt;">phrasalSearch</a> <a class="link_odd_elementSpec" href="#TEI.recurse" title="&lt;recurse&gt;">recurse</a> <a class="link_odd_elementSpec" href="#TEI.resultsLimit" title="&lt;resultsLimit&gt;">resultsLimit</a> <a class="link_odd_elementSpec" href="#TEI.resultsPerPage" title="&lt;resultsPerPage&gt;">resultsPerPage</a> <a class="link_odd_elementSpec" href="#TEI.scoringAlgorithm" title="&lt;scoringAlgorithm&gt;">scoringAlgorithm</a> <a class="link_odd_elementSpec" href="#TEI.searchFile" title="&lt;searchFile&gt;">searchFile</a> <a class="link_odd_elementSpec" href="#TEI.stemmerFolder" title="&lt;stemmerFolder&gt;">stemmerFolder</a> <a class="link_odd_elementSpec" href="#TEI.stopwordsFile" title="&lt;stopwordsFile&gt;">stopwordsFile</a> <a class="link_odd_elementSpec" href="#TEI.totalKwicLength" title="&lt;totalKwicLength&gt;">totalKwicLength</a> <a class="link_odd_elementSpec" href="#TEI.versionFile" title="&lt;versionFile&gt;">versionFile</a> <a class="link_odd_elementSpec" href="#TEI.wildcardSearch" title="&lt;wildcardSearch&gt;">wildcardSearch</a></span></div>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e3439" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e3720" class="pre_eg cdata">
 &lt;content&gt;
  &lt;elementRef key="searchFile"/&gt;
  &lt;elementRef key="versionFile"
@@ -3851,378 +2802,245 @@ element outputFolder { xsd:NCName }<a href="#index.xml-eg-d38e3309" class="ancho
  &lt;elementRef key="resultsLimit"
   minOccurs="0"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e3439" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e3720" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e3446" class="pre_eg cdata">
-element params {  }<a href="#index.xml-eg-d38e3446" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                              <pre id="index.xml-eg-d38e3727" class="pre_eg cdata">
+element params {  }<a href="#index.xml-eg-d38e3727" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.phrasalSearch">
-                  
-                  <h3><span class="headingNumber">Appendix A.1.15 </span><span class="head">&lt;phrasalSearch&gt;</span></h3>
-                  
+                  <h3><span class="headingNumber">Appendix A.1.18 </span><span class="head">&lt;phrasalSearch&gt;</span></h3>
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;phrasalSearch&gt; </span>(<span>Whether or not to support phrasal searches. If this is true, then the maxContexts
                                  setting will be ignored, because all contexts are required to properly support phrasal
                                  search.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.params" title="&lt;params&gt;">params</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="specChildren">
-                                 
                                  <div class="specChild">XSD boolean</div>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <p>Phrasal search functionality enables your users to search for specific phrases by
                                  surrounding them with quotation marks (<code>"</code>), as in many search engines. In order to support this kind of search, <a class="link_ref" href="#TEI.createContexts" title="&lt;createContexts&gt;">&lt;createContexts&gt;</a> must also be set to true as we store contexts for all hits for each token in each
                                  document. Turning this on will make the index larger, because all contexts must be
                                  stored, but once the index is built, it has very little impact on the speed of searches,
                                  so we recommend turning this on. The default value is true.</p>
-                              
                               <p>However, if your site is very large and your user base is unlikely to use phrasal
                                  searching, it may not be worth the additional build time and increased index size.</p>
-                              </td>
-                           </tr>
-                        
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e3515" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e3796" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="boolean"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e3515" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e3796" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e3522" class="pre_eg cdata">
-element phrasalSearch { xsd:boolean }<a href="#index.xml-eg-d38e3522" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                              <pre id="index.xml-eg-d38e3803" class="pre_eg cdata">
+element phrasalSearch { xsd:boolean }<a href="#index.xml-eg-d38e3803" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.recurse">
-                  
-                  <h3><span class="headingNumber">Appendix A.1.16 </span><span class="head">&lt;recurse&gt;</span></h3>
-                  
+                  <h3><span class="headingNumber">Appendix A.1.19 </span><span class="head">&lt;recurse&gt;</span></h3>
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;recurse&gt; </span>(<span>Whether to recurse into subdirectories of the collection directory or not.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.params" title="&lt;params&gt;">params</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="specChildren">
-                                 
                                  <div class="specChild">XSD boolean</div>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e3577" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e3858" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="boolean"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e3577" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e3858" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e3584" class="pre_eg cdata">
-element recurse { xsd:boolean }<a href="#index.xml-eg-d38e3584" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                              <pre id="index.xml-eg-d38e3865" class="pre_eg cdata">
+element recurse { xsd:boolean }<a href="#index.xml-eg-d38e3865" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.resultsLimit">
-                  
-                  <h3><span class="headingNumber">Appendix A.1.17 </span><span class="head">&lt;resultsLimit&gt;</span></h3>
-                  
+                  <h3><span class="headingNumber">Appendix A.1.20 </span><span class="head">&lt;resultsLimit&gt;</span></h3>
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;resultsLimit&gt; </span>(<span>The maximum number of results that can be returned for any search before returning
                                  an error; if the number of documents in a result set exceeds this number, then staticSearch
                                  will not render the results and will provide a message saying that the search returned
                                  too many results. This is usually set to 2000 by default, but you may want to have
                                  a higher or lower limit, depending on the specific structure of your project. </span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.params" title="&lt;params&gt;">params</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="specChildren">
-                                 
                                  <div class="specChild">XSD nonNegativeInteger</div>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <p>This configuration option is meant to prevent errors for sites where a given set of
                                  filters or search terms can return a set of document that can cause a browser's rendering
                                  engine to fail. For smaller collections, it's unlikely that this limit would ever
                                  be reached, but setting a limit may be helpful for large document collections, projects
                                  that want to constrain the number of possible results, or projects with memory-intensive
                                  or complex rendering.</p>
-                              </td>
-                           </tr>
-                        
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e3646" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e3927" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="nonNegativeInteger"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e3646" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e3927" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e3653" class="pre_eg cdata">
-element resultsLimit { xsd:nonNegativeInteger }<a href="#index.xml-eg-d38e3653" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                              <pre id="index.xml-eg-d38e3934" class="pre_eg cdata">
+element resultsLimit { xsd:nonNegativeInteger }<a href="#index.xml-eg-d38e3934" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.resultsPerPage">
-                  
-                  <h3><span class="headingNumber">Appendix A.1.18 </span><span class="head">&lt;resultsPerPage&gt;</span></h3>
-                  
+                  <h3><span class="headingNumber">Appendix A.1.21 </span><span class="head">&lt;resultsPerPage&gt;</span></h3>
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;resultsPerPage&gt; </span>(<span>The maximum number of document results to be displayed per page. All results are displayed
                                  by default; setting resultsPerPage to a positive integer creates a Show More/Show
                                  All widget at the bottom of the batch of results.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.params" title="&lt;params&gt;">params</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="specChildren">
-                                 
                                  <div class="specChild">XSD nonNegativeInteger</div>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <p>For most sites, where the number of results is likely to be in the low thousands,
                                  it's perfectly practical to show all the results at once, because the staticSearch
                                  processor is so fast. However, if you have tens of thousands of documents, and it's
@@ -4231,326 +3049,210 @@ element resultsLimit { xsd:nonNegativeInteger }<a href="#index.xml-eg-d38e3653" 
                                  using this setting. All the results are still generated and output to the page, but
                                  since most of them are hidden until the ‘Show More’ or ‘Show All’ button is clicked,
                                  the browser will render them much more quickly.</p>
-                              </td>
-                           </tr>
-                        
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e3720" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e4001" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="nonNegativeInteger"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e3720" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e4001" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e3727" class="pre_eg cdata">
-element resultsPerPage { xsd:nonNegativeInteger }<a href="#index.xml-eg-d38e3727" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                              <pre id="index.xml-eg-d38e4008" class="pre_eg cdata">
+element resultsPerPage { xsd:nonNegativeInteger }<a href="#index.xml-eg-d38e4008" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.rule">
-                  
-                  <h3><span class="headingNumber">Appendix A.1.19 </span><span class="head">&lt;rule&gt;</span></h3>
-                  
+                  <h3><span class="headingNumber">Appendix A.1.22 </span><span class="head">&lt;rule&gt;</span></h3>
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;rule&gt; </span>(<span>A rule that specifies a document path as XPath in the match attribute, and provides
                                  weighting for search terms found in that context.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Attributes</span></td>
-                           
                            <td class="wovenodd-col2"><a class="link_ref" href="#TEI.att.match" title="att.match">att.match</a> (<span class="attribute">@match</span>) 
-                              
                               <div class="table">
-                                 
                                  <table class="attList">
-                                    
                                     <tr>
-                                       
                                        <td class="odd_label">weight</td>
-                                       
                                        <td class="odd_value">(<span>The weighting to give to a search token found in the context specified by the match
                                              attribute. Set to 0 to completely suppress indexing for a specific context, or greater
                                              than 1 to give stronger weighting.</span>) 
-                                          
                                           <div class="table">
-                                             
                                              <table class="attDef">
-                                                
                                                 <tr>
-                                                   
                                                    <td class="odd_label"><span xml:lang="en" lang="en" class="label">Status</span></td>
-                                                   
                                                    <td class="odd_value"><span xml:lang="en" lang="en"><span class="required">Required</span></span></td>
-                                                   </tr>
-                                                
+                                                </tr>
                                                 <tr>
-                                                   
                                                    <td class="odd_label"><span xml:lang="en" lang="en" class="label">Datatype</span></td>
-                                                   
                                                    <td class="odd_value"><a class="link_ref" href="https://www.w3.org/TR/xmlschema-2/#nonNegativeInteger">nonNegativeInteger</a></td>
-                                                   </tr>
-                                                </table>
-                                             </div>
-                                          </td>
-                                       </tr>
-                                    </table>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                 </table>
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.rules" title="&lt;rules&gt;">rules</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2"><span xml:lang="en" lang="en">Empty element</span></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <p>The rule element is used to identify nodes in the XHTML document collection which
                                  should be treated in a special manner when indexed; either they might be ignored (if
                                  <span class="att">weight</span>=<span class="val">0</span>), or any words found in them might be given greater weight than words in normal contexts
                                  <span class="att">weight</span>&gt;<span class="val">1</span>. Words appearing in headings or titles, for example, might be weighted more heavily,
                                  while navigation menus, banners, or footers might be ignored completely.</p>
-                              </td>
-                           </tr>
-                        
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e3843" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e4125" class="pre_eg cdata">
 &lt;content&gt;
  &lt;empty/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e3843" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e4125" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e3850" class="pre_eg">
-element rule { <a class="link_ref" href="#TEI.att.match" title="att.match">att.match.attributes</a>, attribute weight { text }, empty }<a href="#index.xml-eg-d38e3850" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                              <pre id="index.xml-eg-d38e4132" class="pre_eg">
+element rule { <a class="link_ref" href="#TEI.att.match" title="att.match">att.match.attributes</a>, attribute weight { text }, empty }<a href="#index.xml-eg-d38e4132" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.rules">
-                  
-                  <h3><span class="headingNumber">Appendix A.1.20 </span><span class="head">&lt;rules&gt;</span></h3>
-                  
+                  <h3><span class="headingNumber">Appendix A.1.23 </span><span class="head">&lt;rules&gt;</span></h3>
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;rules&gt; </span>(<span>The set of rules that control weighting of search terms found in specific contexts.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.config" title="&lt;config&gt;">config</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="specChildren">
-                                 
                                  <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.rule" title="&lt;rule&gt;">rule</a></span></div>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e3912" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e4194" class="pre_eg cdata">
 &lt;content&gt;
  &lt;elementRef key="rule" minOccurs="1"
   maxOccurs="unbounded"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e3912" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e4194" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e3919" class="pre_eg">
-element rules { <a class="link_ref" href="#TEI.rule" title="&lt;rule&gt;">rule</a>+ }<a href="#index.xml-eg-d38e3919" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                              <pre id="index.xml-eg-d38e4201" class="pre_eg">
+element rules { <a class="link_ref" href="#TEI.rule" title="&lt;rule&gt;">rule</a>+ }<a href="#index.xml-eg-d38e4201" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.scoringAlgorithm">
-                  
-                  <h3><span class="headingNumber">Appendix A.1.21 </span><span class="head">&lt;scoringAlgorithm&gt;</span></h3>
-                  
+                  <h3><span class="headingNumber">Appendix A.1.24 </span><span class="head">&lt;scoringAlgorithm&gt;</span></h3>
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;scoringAlgorithm&gt; </span>(<span>The scoring algorithm to use for ranking keyword results. Default is "raw" (i.e. weighted
                                  counts)</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.params" title="&lt;params&gt;">params</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2"><span xml:lang="en" lang="en">Empty element</span></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <p><a class="link_ref" href="#TEI.scoringAlgorithm" title="&lt;scoringAlgorithm&gt;">&lt;scoringAlgorithm&gt;</a> is an optional element that specifies which scoring algorithm to use when calculating
                                  the score of a term and thus the order in which the results from a search are sorted.
                                  There are currently two options: </p>
-                              
                               <ul>
-                                 
                                  <li class="item"><span class="val">raw</span>: This is the default option (and so does not need to be set explicitly). The raw
                                     score is simply the sum of all instances of a term (optionally multipled by a configured
                                     weight via the <a class="link_ref" href="#TEI.rule" title="&lt;rule&gt;">&lt;rule&gt;</a>/<span class="att">weight</span> <a class="link_ref" href="#specifyingRules" title="Specifying rules (optional)">configuration</a>) in a document. This will usually provide good results for most document collections.</li>
-                                 
                                  <li class="item"><span class="val">tf-idf</span>: The tf-idf algorithm (term frequency-inverse document frequency) computes the mathematical
                                     relevance of a term within a document relative to the rest of the document collection.
                                     The staticSearch implementation of tf-idf basically follows the textbook definition
@@ -4559,17 +3261,13 @@ element rules { <a class="link_ref" href="#TEI.rule" title="&lt;rule&gt;">rule</
                                     like <a class="link_ref" href="https://lucene.apache.org/core/3_5_0/scoring.html">Lucene</a>, but it may provide useful results for document collections of varying lengths or
                                     in instances where the raw score may be insufficient or misleading. There are a number
                                     of resources on tf-idf scoring, including: <a class="link_ref" href="https://en.wikipedia.org/wiki/Tf%E2%80%93idf">Wikipedia</a> and Christopher D. Manning, Prabhakar Raghavan and Hinrich Schütze, <a class="link_ref" href="https://nlp.stanford.edu/IR-book/html/htmledition/tf-idf-weighting-1.html">Introduction to Information Retrieval</a>, Cambridge University Press. 2008.</li>
-                                 </ul>
-                              </td>
-                           </tr>
-                        
+                              </ul>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e4016" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e4298" class="pre_eg cdata">
 &lt;content&gt;
  &lt;valList type="closed"&gt;
   &lt;valItem ident="raw"&gt;
@@ -4582,228 +3280,148 @@ element rules { <a class="link_ref" href="#TEI.rule" title="&lt;rule&gt;">rule</
   &lt;/valItem&gt;
  &lt;/valList&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e4016" class="anchorlink">⚓</a></pre>Legal values are:
-                              
+    <a href="#index.xml-eg-d38e4298" class="anchorlink">⚓</a></pre>Legal values are:
                               <dl class="valList">
-                                 
                                  <dt><span class="odd_label">raw</span></dt>
-                                 
                                  <dd>(<span>Default: Calculate the score based off of the weighted number of instances of a term
                                        in a text.</span>) <span>raw score</span></dd>
-                                 
                                  <dt><span class="odd_label">tf-idf</span></dt>
-                                 
                                  <dd>(<span>Calculate the score based off of the tf-idf scoring algorithm.</span>)</dd>
-                                 </dl>
-                              </td>
-                           </tr>
-                        
+                              </dl>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e4038" class="pre_eg cdata">
-element scoringAlgorithm { "raw" | "tf-idf" }<a href="#index.xml-eg-d38e4038" class="anchorlink">⚓</a></pre>Legal values are:
-                              
+                              <pre id="index.xml-eg-d38e4320" class="pre_eg cdata">
+element scoringAlgorithm { "raw" | "tf-idf" }<a href="#index.xml-eg-d38e4320" class="anchorlink">⚓</a></pre>Legal values are:
                               <dl class="valList">
-                                 
                                  <dt><span class="odd_label">raw</span></dt>
-                                 
                                  <dd>(<span>Default: Calculate the score based off of the weighted number of instances of a term
                                        in a text.</span>) <span>raw score</span></dd>
-                                 
                                  <dt><span class="odd_label">tf-idf</span></dt>
-                                 
                                  <dd>(<span>Calculate the score based off of the tf-idf scoring algorithm.</span>)</dd>
-                                 </dl>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                              </dl>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.searchFile">
-                  
-                  <h3><span class="headingNumber">Appendix A.1.22 </span><span class="head">&lt;searchFile&gt;</span></h3>
-                  
+                  <h3><span class="headingNumber">Appendix A.1.25 </span><span class="head">&lt;searchFile&gt;</span></h3>
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;searchFile&gt; </span>(<span>The search file (aka page) that will be the primary access point for the staticSearch.
                                  Note that this page must be at the root of the collection directory.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.params" title="&lt;params&gt;">params</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="specChildren">
-                                 
                                  <div class="specChild">XSD anyURI</div>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <p>The search page is a regular HTML page which forms part of your site. The only important
                                  characteristic it must have is a <span class="gi">&lt;div&gt;</span> element with <span class="att">id</span>=<span class="val">staticSearch</span>, whose contents will be rewritten by the staticSearch build process. See <a class="link_ptr" href="#searchPage" title="Creating a search page"><span class="headingNumber">8.6 </span>Creating a search page</a>.</p>
-                              </td>
-                           </tr>
-                        
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e4127" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e4408" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="anyURI"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e4127" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e4408" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e4134" class="pre_eg cdata">
-element searchFile { xsd:anyURI }<a href="#index.xml-eg-d38e4134" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                              <pre id="index.xml-eg-d38e4415" class="pre_eg cdata">
+element searchFile { xsd:anyURI }<a href="#index.xml-eg-d38e4415" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.stemmerFolder">
-                  
-                  <h3><span class="headingNumber">Appendix A.1.23 </span><span class="head">&lt;stemmerFolder&gt;</span></h3>
-                  
+                  <h3><span class="headingNumber">Appendix A.1.26 </span><span class="head">&lt;stemmerFolder&gt;</span></h3>
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;stemmerFolder&gt; </span>(<span>The name of a folder inside the staticSearch /stemmers/ folder, in which the JavaScript
                                  and XSLT implementations of stemmers can be found. If left blank, then the staticSearch
                                  default English stemmer (en) will be used.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.params" title="&lt;params&gt;">params</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="specChildren">
-                                 
                                  <div class="specChild">XSD NCName</div>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <p>The staticSearch project currently has only two real stemmers: an implementation of
                                  the Porter 2 algorithm for modern English, and an implementation of the French Snowball
                                  stemmer. These appear in the <span class="ident">/stemmers/en/</span> and <span class="ident">/stemmers/fr/</span> folders. The default value for this parameter is <span class="val">en</span>; to use the French stemmer, use <span class="val">fr</span>. We will be adding more stemmers as the project develops. However, if your document
                                  collection is not English or French, you have a couple of options, one hard and one
                                  easy. </p>
-                              
                               <ul>
-                                 
                                  <li class="item"><em>Hard option</em>: implement your own stemmers. You will need to write two implementations of the stemmer
                                     algorithm, one in XSLT (which must be named <span class="ident">ssStemmer.xsl</span>) and one in JavaScript (<span class="ident">ssStemmer.js</span>), and confirm that they both generate the same results. The XSLT stemmer is used
                                     in the generation of the index files at build time, and the JavaScript version is
                                     used to stem the user's input in the search page. You can look at the existing implementations
                                     in the <span class="ident">/stemmers/en/</span> folder to see how the stemmers need to be constructed. Place your stemmers in a folder
                                     called <span class="ident">/stemmers/[yourlang]/</span>, and specify <span class="val">yourlang</span> in the configuration file.</li>
-                                 
                                  <li class="item"><em>Easy option</em>: Use the <span class="ident">identity stemmer</span> (which is equivalent to turning off stemming completely), and make sure wildcard
                                     searching is turned on. Then your users can search using wildcards instead of having
                                     their search terms automatically stemmed. To do this, specify the value <span class="val">identity</span> in your configuration file.</li>
-                                 </ul>
-                              
+                              </ul>
                               <p> Another alternative is the <span class="ident">stripDiacritics</span> stemmer. Like the <span class="ident">identity stemmer</span>, this is not really a stemmer at all; what it does is to strip out all combining
                                  diacritics from tokens. This is a useful approach if you document collection contains
                                  texts with accents and diacritics, but your users may be unfamiliar with the use of
@@ -4813,100 +3431,65 @@ element searchFile { xsd:anyURI }<a href="#index.xml-eg-d38e4134" class="anchorl
                                  and user-friendly search engine in the absence of a sophisticated stemmer, or for
                                  cases where there are mixed languages so a single stemmer will not do. To use this
                                  option, specify the value <span class="val">stripDiacritics</span> in your configuration file.</p>
-                              </td>
-                           </tr>
-                        
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e4243" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e4524" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="NCName"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e4243" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e4524" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e4250" class="pre_eg cdata">
-element stemmerFolder { xsd:NCName }<a href="#index.xml-eg-d38e4250" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                              <pre id="index.xml-eg-d38e4531" class="pre_eg cdata">
+element stemmerFolder { xsd:NCName }<a href="#index.xml-eg-d38e4531" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.stopwordsFile">
-                  
-                  <h3><span class="headingNumber">Appendix A.1.24 </span><span class="head">&lt;stopwordsFile&gt;</span></h3>
-                  
+                  <h3><span class="headingNumber">Appendix A.1.27 </span><span class="head">&lt;stopwordsFile&gt;</span></h3>
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;stopwordsFile&gt; </span>(<span>The relative path (from the config file) to a text file containing a list of stopwords
                                  (words to be ignored when indexing). </span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.params" title="&lt;params&gt;">params</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="specChildren">
-                                 
                                  <div class="specChild">XSD anyURI</div>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <p>A stopword is a word that will not be indexed, because it is too common (<span class="mentioned">the</span>, <span class="mentioned">a</span>, <span class="mentioned">you</span> and so on). There are common stopwords files for most languages available on the
                                  Web, but it is probably a good idea to take one of these and customize it for your
                                  project, since there will be words in the website which are so common that it makes
@@ -4916,199 +3499,129 @@ element stemmerFolder { xsd:NCName }<a href="#index.xml-eg-d38e4250" class="anch
                                  stopwords for English, which you'll find in <span class="ident">xsl/english_stopwords.txt</span>. One way to find appropriate stopwords for your site is to generate your index, then
                                  search for the largest JSON index files that are generated, to see if they might be
                                  too common to be useful as search terms. You can also use the <span class="titlem">Word Frequency</span> table in the generated staticSearch report (see <a class="link_ptr" href="#theStaticSearchReport" title="Generated report"><span class="headingNumber">8.9 </span>Generated report</a>).</p>
-                              </td>
-                           </tr>
-                        
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e4329" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e4610" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="anyURI"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e4329" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e4610" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e4336" class="pre_eg cdata">
-element stopwordsFile { xsd:anyURI }<a href="#index.xml-eg-d38e4336" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                              <pre id="index.xml-eg-d38e4617" class="pre_eg cdata">
+element stopwordsFile { xsd:anyURI }<a href="#index.xml-eg-d38e4617" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.totalKwicLength">
-                  
-                  <h3><span class="headingNumber">Appendix A.1.25 </span><span class="head">&lt;totalKwicLength&gt;</span></h3>
-                  
+                  <h3><span class="headingNumber">Appendix A.1.28 </span><span class="head">&lt;totalKwicLength&gt;</span></h3>
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;totalKwicLength&gt; </span>(<span>If createContexts is set to true, then this parameter controls the length (in words)
                                  of the harvested keyword-in-context string.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.params" title="&lt;params&gt;">params</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="specChildren">
-                                 
                                  <div class="specChild">XSD nonNegativeInteger</div>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <p>Obviously, the longer the keyword-in-context strings are, the larger the individual
                                  index files will be, but the more useful the KWICs will be for users looking at the
                                  search results. Note that the phrasal searching relies on the KWICs and thus longer
                                  KWICs allow for longer phrasal searches.</p>
-                              </td>
-                           </tr>
-                        
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e4398" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e4679" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="nonNegativeInteger"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e4398" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e4679" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e4405" class="pre_eg cdata">
-element totalKwicLength { xsd:nonNegativeInteger }<a href="#index.xml-eg-d38e4405" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                              <pre id="index.xml-eg-d38e4686" class="pre_eg cdata">
+element totalKwicLength { xsd:nonNegativeInteger }<a href="#index.xml-eg-d38e4686" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.versionFile">
-                  
-                  <h3><span class="headingNumber">Appendix A.1.26 </span><span class="head">&lt;versionFile&gt;</span></h3>
-                  
+                  <h3><span class="headingNumber">Appendix A.1.29 </span><span class="head">&lt;versionFile&gt;</span></h3>
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;versionFile&gt; </span>(<span>The relative path to a text file containing a single version identifier (such as 1.5,
                                  123456, or 06ad419). This will be used to create unique filenames for JSON resources,
                                  so that the browser will not use cached versions of older index files.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.params" title="&lt;params&gt;">params</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="specChildren">
-                                 
                                  <div class="specChild">XSD anyURI</div>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <p><a class="link_ref" href="#TEI.versionFile" title="&lt;versionFile&gt;">&lt;versionFile&gt;</a> enables you to specify the path to a plain-text file containing a simple version
                                  number for the project. This might take the form of a software-release-style version
                                  number such as <span class="val">1.5</span>, or it might be a Subversion revision number or a Git commit hash. It should not
@@ -5119,322 +3632,210 @@ element totalKwicLength { xsd:nonNegativeInteger }<a href="#index.xml-eg-d38e440
                                  files will not be used because the new version will have different filenames. The
                                  path specified is relative to the location of the configuration file (or absolute,
                                  if you wish).</p>
-                              </td>
-                           </tr>
-                        
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e4473" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e4754" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="anyURI"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e4473" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e4754" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e4480" class="pre_eg cdata">
-element versionFile { xsd:anyURI }<a href="#index.xml-eg-d38e4480" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                              <pre id="index.xml-eg-d38e4761" class="pre_eg cdata">
+element versionFile { xsd:anyURI }<a href="#index.xml-eg-d38e4761" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.wildcardSearch">
-                  
-                  <h3><span class="headingNumber">Appendix A.1.27 </span><span class="head">&lt;wildcardSearch&gt;</span></h3>
-                  
+                  <h3><span class="headingNumber">Appendix A.1.30 </span><span class="head">&lt;wildcardSearch&gt;</span></h3>
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">&lt;wildcardSearch&gt; </span>(<span>Whether or not to support wildcard searches. Note that wildcard searches are more
                                  effective when phrasal searching is also turned on, because the contexts available
                                  for phrasal searches are also used to provide wildcard results.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Namespace</span></td>
-                           
                            <td class="wovenodd-col2">http://hcmc.uvic.ca/ns/staticSearch</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Contained by</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="parent">
-                                 
                                  <div class="specChildren">
-                                    
                                     <div class="specChild"><span class="specChildModule">ss: </span><span class="specChildElements"><a class="link_odd_elementSpec" href="#TEI.params" title="&lt;params&gt;">params</a></span></div>
-                                    </div>
                                  </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">May contain</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="specChildren">
-                                 
                                  <div class="specChild">XSD boolean</div>
-                                 </div>
-                              </td>
-                           </tr>
-                        
+                              </div>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <p>Wildcard searching can coexist with stemmed searching, but it is especially useful
                                  when stemming is not available, either because there is no available stemmer for the
                                  language of the site, or because the site contains multiple languages. Unless your
                                  site is particularly large, we recommend turning on wildcard searching, and therefore
                                  also phrasal searching (<a class="link_ref" href="#TEI.phrasalSearch" title="&lt;phrasalSearch&gt;">&lt;phrasalSearch&gt;</a>).</p>
-                              </td>
-                           </tr>
-                        
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Content model</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e4546" class="pre_eg cdata">
+                              <pre id="index.xml-eg-d38e4827" class="pre_eg cdata">
 &lt;content&gt;
  &lt;dataRef name="boolean"/&gt;
 &lt;/content&gt;
-    <a href="#index.xml-eg-d38e4546" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        
+    <a href="#index.xml-eg-d38e4827" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Schema Declaration</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
-                              <pre id="index.xml-eg-d38e4553" class="pre_eg cdata">
-element wildcardSearch { xsd:boolean }<a href="#index.xml-eg-d38e4553" class="anchorlink">⚓</a></pre>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                              <pre id="index.xml-eg-d38e4834" class="pre_eg cdata">
+element wildcardSearch { xsd:boolean }<a href="#index.xml-eg-d38e4834" class="anchorlink">⚓</a></pre>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
                </div>
-            
+            </div>
             <div class="teidiv1" id="index.xml-back.1_div.1_div.2">
-               
                <h3><span class="headingNumber">Appendix A.2 </span><span class="head">Attribute classes</span></h3>
-               
                <div class="refdoc" id="TEI.att.labelled">
-                  
                   <h3><span class="headingNumber">Appendix A.2.1 </span><span class="head">att.labelled</span></h3>
-                  
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">att.labelled</span> (<span>A class providing a label attribute that can be used to identify/describe contexts.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Members</span></td>
-                           
                            <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_elementSpec" href="#TEI.context" title="&lt;context&gt;">context</a></span></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Attributes</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="table">
-                                 
                                  <table class="attList">
-                                    
                                     <tr>
-                                       
                                        <td class="odd_label">label</td>
-                                       
                                        <td class="odd_value">(<span>A string identifier specifying the name for a given context.</span>) 
-                                          
                                           <div class="table">
-                                             
                                              <table class="attDef">
-                                                
                                                 <tr>
-                                                   
                                                    <td class="odd_label"><span xml:lang="en" lang="en" class="label">Status</span></td>
-                                                   
                                                    <td class="odd_value"><span xml:lang="en" lang="en">Optional</span></td>
-                                                   </tr>
-                                                
+                                                </tr>
                                                 <tr>
-                                                   
                                                    <td class="odd_label"><span xml:lang="en" lang="en" class="label">Datatype</span></td>
-                                                   
                                                    <td class="odd_value"><a class="link_ref" href="https://www.w3.org/TR/xmlschema-2/#string">string</a></td>
-                                                   </tr>
-                                                
+                                                </tr>
                                                 <tr>
-                                                   
                                                    <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Note</span></td>
-                                                   
                                                    <td class="wovenodd-col2">
-                                                      
                                                       <p>When describing a <a class="link_ref" href="#TEI.context" title="&lt;context&gt;">&lt;context&gt;</a>, the <span class="att">label</span> attribute names a component of the page that can be searched within (see <a class="link_ptr" href="#searchOnlyIn" title="Specifying searchable contexts (search only in)"><span class="headingNumber">8.5.5 </span>Specifying searchable contexts (search only in)</a>).</p>
-                                                      </td>
-                                                   </tr>
-                                                </table>
-                                             </div>
-                                          </td>
-                                       </tr>
-                                    </table>
-                                 </div>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                                                   </td>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                 </table>
+                              </div>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
-               
+               </div>
                <div class="refdoc" id="TEI.att.match">
-                  
                   <h3><span class="headingNumber">Appendix A.2.2 </span><span class="head">att.match</span></h3>
-                  
                   <div class="table">
-                     
                      <table class="wovenodd">
-                        
                         <tr>
-                           
                            <td colspan="2" class="wovenodd-col2"><span class="label">att.match</span> (<span>A class providing attributes that enable specification of document locations.</span>)</td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Module</span></td>
-                           
                            <td class="wovenodd-col2">ss — <a class="link_ref" href="#schemaSpec" title="Schema specification and tag documentation">Schema specification and tag documentation</a></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Members</span></td>
-                           
                            <td class="wovenodd-col2"><span class="showmembers1"><a class="link_odd_elementSpec" href="#TEI.context" title="&lt;context&gt;">context</a> <a class="link_odd_elementSpec" href="#TEI.exclude" title="&lt;exclude&gt;">exclude</a> <a class="link_odd_elementSpec" href="#TEI.rule" title="&lt;rule&gt;">rule</a></span></td>
-                           </tr>
-                        
+                        </tr>
                         <tr>
-                           
                            <td class="wovenodd-col1"><span xml:lang="en" lang="en" class="label">Attributes</span></td>
-                           
                            <td class="wovenodd-col2">
-                              
                               <div class="table">
-                                 
                                  <table class="attList">
-                                    
                                     <tr>
-                                       
                                        <td class="odd_label">match</td>
-                                       
                                        <td class="odd_value">(<span>An XPath equivalent to the @match attribute of an xsl:template, which specifies a
                                              context in a document.</span>) 
-                                          
                                           <div class="table">
-                                             
                                              <table class="attDef">
-                                                
                                                 <tr>
-                                                   
                                                    <td class="odd_label"><span xml:lang="en" lang="en" class="label">Status</span></td>
-                                                   
                                                    <td class="odd_value"><span xml:lang="en" lang="en"><span class="required">Required</span></span></td>
-                                                   </tr>
-                                                
+                                                </tr>
                                                 <tr>
-                                                   
                                                    <td class="odd_label"><span xml:lang="en" lang="en" class="label">Datatype</span></td>
-                                                   
                                                    <td class="odd_value"><a class="link_ref" href="https://www.w3.org/TR/xmlschema-2/#string">string</a></td>
-                                                   </tr>
-                                                </table>
-                                             </div>
-                                          </td>
-                                       </tr>
-                                    </table>
-                                 </div>
-                              </td>
-                           </tr>
-                        </table>
-                     </div>
+                                                </tr>
+                                             </table>
+                                          </div>
+                                       </td>
+                                    </tr>
+                                 </table>
+                              </div>
+                           </td>
+                        </tr>
+                     </table>
                   </div>
                </div>
-            </section>
-         </div>
+            </div>
+         </section>
+      </div>
       <!--Notes in [TEI]-->
-      
       <div class="notes">
-         
          <div class="noteHeading">Notes</div>
-         
          <div class="note" id="Note1"><span class="noteLabel">1 </span><div class="noteBody">This example taken from Thomas S. Kuhn, <span class="titlem">The Structure of Scientific Revolutions</span> (50th anniversary edition), University of Chicago Press, 2012: p. 191.</div> <a class="link_return" title="Go back to text" href="#Note1_return">↵</a></div>
-         
          <div class="note" id="Note2"><span class="noteLabel">2 </span><div class="noteBody">Note that you can use either <span class="ident">ssConfigFile</span> or <span class="ident">ssConfig</span> to provide the build with the full path or relative path, respectively, of your configuration
                file.</div> <a class="link_return" title="Go back to text" href="#Note2_return">↵</a></div>
-         </div>
-      
+      </div>
       <div class="stdfooter autogenerated">
-         
          <div class="footer"><!--standard links to project, institution etc--><a class="plain" href="http://www.example.com/"></a> <a class="plain" href="index.html">Home</a> <a class="plain" href="#">Feedback</a> </div>
-         
          <address>Martin Holmes and Joey Takeda. Date: 2019-2023<br/>
             <!--
-	  Generated from index.xml using XSLT stylesheets version 7.55.0a
+	  Generated from index.xml using XSLT stylesheets version 7.56.0a
 	       based on http://www.tei-c.org/Stylesheets/
-	       on 2023-03-07T23:18:14Z.
+	       on 2023-06-14T18:02:37Z.
 	       SAXON HE 11.4.
 		 --></address>
-         </div>
-      </body>
-   </html>
+      </div>
+   </body>
+</html>

--- a/schema/staticSearch.odd
+++ b/schema/staticSearch.odd
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <TEI xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:svg="http://www.w3.org/2000/svg"
   xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns="http://www.tei-c.org/ns/1.0"
-  xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+  xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+  xmlns:xh="http://www.w3.org/1999/xhtml">
   <teiHeader>
     <fileDesc>
       <titleStmt>
@@ -1552,6 +1553,7 @@
               <elementRef key="rules" minOccurs="0"/>
               <elementRef key="contexts" minOccurs="0"/>
               <elementRef key="excludes" minOccurs="0"/>
+              <elementRef key="filters" minOccurs="0"/>
             </content>
             <attList>
               <attDef ident="version" usage="rec">
@@ -2143,6 +2145,68 @@
                 different locations.</p>
             </remarks>
           </elementSpec>
+          
+          <elementSpec ident="filters" module="ss" ns="http://hcmc.uvic.ca/ns/staticSearch">
+            <gloss>Wrapper for filter elements in the configuration file</gloss>
+            <desc>The optional filters/filter part of the configuration file allows the
+            user to specify custom labels with HTML markup for specific filters, so they
+            are not limited by the label supplied in the XHTML meta/@name attribute.</desc>
+            <content>
+              <elementRef key="filter" minOccurs="1" maxOccurs="unbounded"/>
+            </content>
+          </elementSpec>
+          
+          <elementSpec ident="filter" module="ss" ns="http://hcmc.uvic.ca/ns/staticSearch">
+            <gloss>Allows specification of a custom label for a filter on the search page</gloss>
+            <desc>Filters are identified through plain-text labels defined as XHTML meta/@name
+            attributes in the document headers. This element allows a user to specify a richer
+            label for a particular filter by using HTML code. Multiple labels may be specified
+            in different languages. The <att>filterName</att> attribute must be supplied, and 
+            must be identical to the XHTML meta/@name attribute for the filter as it appears
+            in the HTML document heads.</desc>
+            <content>
+              <elementRef key="label" minOccurs="1" maxOccurs="unbounded"/>
+            </content>
+            <attList>
+              <attDef ident="filterName" usage="req">
+                <datatype>
+                  <dataRef key="teidata.text"/>
+                </datatype>
+              </attDef>
+            </attList>
+          </elementSpec>
+          
+          <!-- HTML finds its way into our config file now, so here is where we 
+               do some rudimentary constraining. -->
+          <moduleSpec ident="ssHTML">
+            <desc>A module to encapsulate HTML elements (in the XHTML namespace)
+            which are used as part of our configuration setup, enabling users to 
+            specify e.g. rich HTML markup inside labels that will appear on the 
+            search page.</desc>
+          </moduleSpec>
+          
+          <elementSpec ident="label" module="ssHTML" ns="http://www.w3.org/1999/xhtml">
+            <gloss>An HTML label</gloss>
+            <desc>A standard HTML label element, within which other HTML content can 
+            be included. We do not prescribe or validate the content model; see e.g.
+            https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label
+            for information.</desc>
+            <content>
+              <alternate minOccurs="1" maxOccurs="unbounded">
+              <anyElement require="http://www.w3.org/1999/xhtml" minOccurs="0" maxOccurs="unbounded"/>
+                <textNode/>
+              </alternate>
+            </content>
+            <attList>
+              <attDef ident="lang" usage="rec">
+                <gloss>The language of this label</gloss>
+                <desc>Multiple labels may be supplied in different languages if required. The value
+                of this attribute should be a valid language identifier per BCP 47.</desc>
+                <datatype><dataRef key="teidata.language"/></datatype>
+              </attDef>
+            </attList>
+          </elementSpec>
+          
         </schemaSpec>
       </div>
     </back>

--- a/schema/staticSearch.rng
+++ b/schema/staticSearch.rng
@@ -5,15 +5,45 @@
           xmlns:xlink="http://www.w3.org/1999/xlink"
           datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
           ns="http://hcmc.uvic.ca/ns/staticSearch"><!--
-Schema generated from ODD source 2023-03-07T23:18:05Z. 2019-2023.
-TEI Edition: Version 4.5.0. Last updated on
-        25th October 2022, revision 3e98e619e
-TEI Edition Location: https://www.tei-c.org/Vault/P5/Version 4.5.0/
+Schema generated from ODD source 2023-06-14T18:02:28Z. 2019-2023.
+TEI Edition: Version 4.6.0. Last updated on
+        4th April 2023, revision f18deffba
+TEI Edition Location: https://www.tei-c.org/Vault/P5/Version 4.6.0/
   
 --><!--Free to anyone for any purpose-->
    <sch:ns xmlns:sch="http://purl.oclc.org/dsdl/schematron"
             prefix="tei"
             uri="http://www.tei-c.org/ns/1.0"/>
+   <define name="anyElement-label">
+      <element>
+         <anyName>
+            <except>
+               <nsName ns="http://hcmc.uvic.ca/ns/staticSearch"/>
+            </except>
+         </anyName>
+         <zeroOrMore>
+            <attribute>
+               <anyName/>
+            </attribute>
+         </zeroOrMore>
+         <zeroOrMore>
+            <choice>
+               <text/>
+               <ref name="anyElement-label"/>
+            </choice>
+         </zeroOrMore>
+      </element>
+      <ns xmlns="http://purl.oclc.org/dsdl/schematron"
+           prefix="xh"
+           uri="http://www.w3.org/1999/xhtml"/>
+      <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="d10e3356-constraint">
+         <rule context="xh:label">
+            <report test="descendant::*[not(namespace-uri(.) =               ('http://www.w3.org/1999/xhtml', 'http://www.tei-c.org/ns/1.0'))]">label descendants must be in the
+              namespaces
+              'http://www.w3.org/1999/xhtml', 'http://www.tei-c.org/ns/1.0'</report>
+         </rule>
+      </pattern>
+   </define>
    <define name="config">
       <element name="config" ns="http://hcmc.uvic.ca/ns/staticSearch">
          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(The root element for the Search Generator configuration file.) </a:documentation>
@@ -26,6 +56,9 @@ TEI Edition Location: https://www.tei-c.org/Vault/P5/Version 4.5.0/
          </optional>
          <optional>
             <ref name="excludes"/>
+         </optional>
+         <optional>
+            <ref name="filters"/>
          </optional>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
@@ -332,6 +365,45 @@ TEI Edition Location: https://www.tei-c.org/Vault/P5/Version 4.5.0/
               be placed in the site search. This should conform with the 
               XML Name specification.) </a:documentation>
          <data type="NCName"/>
+      </element>
+   </define>
+   <define name="filters">
+      <element name="filters" ns="http://hcmc.uvic.ca/ns/staticSearch">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(Wrapper for filter elements in the configuration file) The optional filters/filter part of the configuration file allows the user to specify custom labels with HTML markup for specific filters, so they are not limited by the label supplied in the XHTML meta/@name attribute.</a:documentation>
+         <oneOrMore>
+            <ref name="filter"/>
+         </oneOrMore>
+      </element>
+   </define>
+   <define name="filter">
+      <element name="filter" ns="http://hcmc.uvic.ca/ns/staticSearch">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(Allows specification of a custom label for a filter on the search page) Filters are identified through plain-text labels defined as XHTML meta/@name attributes in the document headers. This element allows a user to specify a richer label for a particular filter by using HTML code. Multiple labels may be specified in different languages. The <code xmlns="http://www.w3.org/1999/xhtml">@filterName</code> attribute must be supplied, and must be identical to the XHTML meta/@name attribute for the filter as it appears in the HTML document heads.</a:documentation>
+         <oneOrMore>
+            <ref name="label"/>
+         </oneOrMore>
+         <attribute name="filterName">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+         </attribute>
+         <empty/>
+      </element>
+   </define>
+   <define name="label">
+      <element name="label" ns="http://www.w3.org/1999/xhtml">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(An HTML label) A standard HTML label element, within which other HTML content can be included. We do not prescribe or validate the content model; see e.g. https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label for information.</a:documentation>
+         <oneOrMore>
+            <choice>
+               <zeroOrMore>
+                  <ref name="anyElement-label"/>
+               </zeroOrMore>
+               <text/>
+            </choice>
+         </oneOrMore>
+         <optional>
+            <attribute name="lang">
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(The language of this label) Multiple labels may be supplied in different languages if required. The value of this attribute should be a valid language identifier per BCP 47.</a:documentation>
+            </attribute>
+         </optional>
+         <empty/>
       </element>
    </define>
    <start>

--- a/schema/staticSearch.sch
+++ b/schema/staticSearch.sch
@@ -8,5 +8,22 @@
             xmlns:xlink="http://www.w3.org/1999/xlink"
             prefix="tei"
             uri="http://www.tei-c.org/ns/1.0"/>
+   <ns xmlns="http://purl.oclc.org/dsdl/schematron"
+        xmlns:tei="http://www.tei-c.org/ns/1.0"
+        xmlns:teix="http://www.tei-c.org/ns/Examples"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        prefix="xh"
+        uri="http://www.w3.org/1999/xhtml"/>
+   <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+             xmlns:tei="http://www.tei-c.org/ns/1.0"
+             xmlns:teix="http://www.tei-c.org/ns/Examples"
+             xmlns:xlink="http://www.w3.org/1999/xlink"
+             id="d10e3356-constraint">
+      <rule context="xh:label">
+         <report test="descendant::*[not(namespace-uri(.) =               ('http://www.w3.org/1999/xhtml', 'http://www.tei-c.org/ns/1.0'))]">label descendants must be in the
+              namespaces
+              'http://www.w3.org/1999/xhtml', 'http://www.tei-c.org/ns/1.0'</report>
+      </rule>
+   </pattern>
    <sch:diagnostics/>
 </sch:schema>

--- a/xsl/create_config_xsl.xsl
+++ b/xsl/create_config_xsl.xsl
@@ -270,6 +270,16 @@
     </xd:doc>
     <xsl:variable name="contexts" select="$configDoc//contexts/context" as="element(context)*"/>
     
+    <xd:doc>
+        <xd:desc>
+            <xd:p>The <xd:ref name="filters" type="variable">filters</xd:ref> variable is
+                a sequence of 0 or more filter elements that may be specified by the 
+                user wanting more control over filter labels.</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:variable name="filters" select="$configDoc//filters/filter" as="element(filter)*"/>
+    
+    
     <!--**************************************************************
        *                                                            * 
        *                         TEMPLATES                          *
@@ -522,6 +532,8 @@
         <xso:variable name="hasExclusions" 
             select="{if ($configDoc//exclude) then 'true' else 'false'}()"/>
         
+        <xso:variable name="hasFilters" 
+            select="{if ($configDoc//filter) then 'true' else 'false'}()"/>
         
         <xso:template name="echoParams">
             <xso:if test="$verbose">

--- a/xsl/create_config_xsl.xsl
+++ b/xsl/create_config_xsl.xsl
@@ -750,7 +750,7 @@ tokenization.
         it in any special way.</xd:desc>
     </xd:doc>
     <xsl:template name="createFilterLabels" exclude-result-prefixes="#all">
-        <xso:variable name="filterLabels" as="element(hcmc:filters)">
+        <xso:variable name="filterLabels" as="element(hcmc:filter)*">
             <xsl:sequence select="$filters"/>
         </xso:variable>
     </xsl:template>

--- a/xsl/create_config_xsl.xsl
+++ b/xsl/create_config_xsl.xsl
@@ -403,6 +403,14 @@
                     </xsl:message>
                 </xsl:if>
                 
+                <xsl:if test="not(empty($filters))">
+                    <xsl:call-template name="createFilterLabels"/>
+                    <xsl:message use-when="$verbose">
+                        <xsl:message>Create filter labels</xsl:message>
+                        <xsl:message><xsl:call-template name="createFilterLabels" exclude-result-prefixes="#all"/></xsl:message>
+                    </xsl:message>
+                </xsl:if>
+                
                 
             </xso:stylesheet>
             
@@ -735,6 +743,16 @@ tokenization.
                 <xso:apply-templates select="node()" mode="#current"/>
             </xso:copy>
         </xso:template>
+    </xsl:template>
+    
+    <xd:doc>
+        <xd:desc>The <xd:ref name="createFilterLabels" type="template">createFilterLabels</xd:ref> template creates a copy of the original filter data in a variable; there's no real reason to process 
+        it in any special way.</xd:desc>
+    </xd:doc>
+    <xsl:template name="createFilterLabels" exclude-result-prefixes="#all">
+        <xso:variable name="filterLabels" as="element(hcmc:filters)">
+            <xsl:sequence select="$filters"/>
+        </xso:variable>
     </xsl:template>
     
  

--- a/xsl/create_config_xsl.xsl
+++ b/xsl/create_config_xsl.xsl
@@ -532,7 +532,7 @@
         <xso:variable name="hasExclusions" 
             select="{if ($configDoc//exclude) then 'true' else 'false'}()"/>
         
-        <xso:variable name="hasFilters" 
+        <xso:variable name="hasFilterLabels" 
             select="{if ($configDoc//filter) then 'true' else 'false'}()"/>
         
         <xso:template name="echoParams">

--- a/xsl/json.xsl
+++ b/xsl/json.xsl
@@ -1157,26 +1157,17 @@
     </xsl:template>
     
     <xd:doc>
-        <xd:desc>Template to convert an hcmc:filters element to a JSON array.</xd:desc>
+        <xd:desc>Template to convert an hcmc:filters element to a JSON array. Note that 
+        we do not currently bother serializing the html:label element inside an hcmc:filter 
+        into the JSON; for the moment, we just record the fact that a custom label
+        was supplied.</xd:desc>
     </xd:doc>
     <xsl:template match="hcmc:filters" mode="configToArray">
-        <j:array key="filters">
-            <j:map>
-                <xsl:apply-templates mode="#current"/>
-            </j:map>
+        <j:array key="filtersWithCustomLabels">
+                <xsl:for-each select="child::hcmc:filter">
+                    <j:string><xsl:value-of select="@filterName"/></j:string>
+                </xsl:for-each>
         </j:array>
-    </xsl:template>
-    
-    <xd:doc>
-        <xd:desc>Template to convert any child of an hcmc:filters element to a JSON value.
-        NOTE: This is ugly and only saves the text, but this output JSON is informational only
-        so it seems like overkill to add routines for serializing HTML as escaped text.</xd:desc>
-    </xd:doc>
-    <xsl:template match="hcmc:filters/hcmc:*" mode="configToArray">
-        <xsl:element namespace="http://www.w3.org/2005/xpath-functions" name="{if (text() castable as xs:integer) then 'number' else 'string'}">
-            <xsl:attribute name="key" select="local-name()"/>
-            <xsl:sequence select="normalize-space(.)"/>
-        </xsl:element>
     </xsl:template>
     
     <xd:doc>

--- a/xsl/json.xsl
+++ b/xsl/json.xsl
@@ -1156,8 +1156,28 @@
         </xsl:element>
     </xsl:template>
     
+    <xd:doc>
+        <xd:desc>Template to convert an hcmc:filters element to a JSON array.</xd:desc>
+    </xd:doc>
+    <xsl:template match="hcmc:filters" mode="configToArray">
+        <j:array key="filters">
+            <j:map>
+                <xsl:apply-templates mode="#current"/>
+            </j:map>
+        </j:array>
+    </xsl:template>
     
-    
+    <xd:doc>
+        <xd:desc>Template to convert any child of an hcmc:filters element to a JSON value.
+        NOTE: This is ugly and only saves the text, but this output JSON is informational only
+        so it seems like overkill to add routines for serializing HTML as escaped text.</xd:desc>
+    </xd:doc>
+    <xsl:template match="hcmc:filters/hcmc:*" mode="configToArray">
+        <xsl:element namespace="http://www.w3.org/2005/xpath-functions" name="{if (text() castable as xs:integer) then 'number' else 'string'}">
+            <xsl:attribute name="key" select="local-name()"/>
+            <xsl:sequence select="normalize-space(.)"/>
+        </xsl:element>
+    </xsl:template>
     
     <xd:doc>
         <xd:desc><xd:ref name="hcmc:normalize-boolean">hcmc:normalize-boolean</xd:ref>

--- a/xsl/makeSearchPage.xsl
+++ b/xsl/makeSearchPage.xsl
@@ -622,15 +622,14 @@
     <xsl:function name="hcmc:getFilterLabel" as="element()">
         <xsl:param name="filterName" as="xs:string"/>
         <xsl:param name="filterId" as="xs:string"/>    
-        <xsl:message expand-text="yes">Filter name: {$filterName}; filter id: {$filterId}; filters to check: {count($filterLabels/hcmc:filter)}</xsl:message>
+        <xsl:message expand-text="yes">Filter name: {$filterName}; filter id: {$filterId}; filters to check: {count($filterLabels)}</xsl:message>
         <xsl:choose>
-            <xsl:when test="$filterLabels/hcmc:filter[@filterName=$filterName]">
-                <xsl:variable name="currLabel" select="$filterLabels/hcmc:filter[@filterName=$filterName][1]/*[1]"/>
+            <xsl:when test="$filterLabels[@filterName=$filterName]">
+                <xsl:variable name="currLabel" select="$filterLabels[@filterName=$filterName][1]/*[1]"/>
                 <xsl:copy select="$currLabel">
                     <xsl:copy-of select="$currLabel/@*[not(local-name() = 'for')]"/>
                     <xsl:attribute name="for" select="$filterId"/>
                     <xsl:copy-of select="$currLabel/node()"/>
-                    <xsl:if test="starts-with($filterId, 'ssBool')"><xsl:text>: </xsl:text></xsl:if>
                 </xsl:copy>
             </xsl:when>
             <xsl:otherwise>

--- a/xsl/makeSearchPage.xsl
+++ b/xsl/makeSearchPage.xsl
@@ -307,7 +307,6 @@
                                     <fieldset class="ssFieldset" title="{$filterName}" id="{$filterId}">
                                         <legend>
                                             <xsl:sequence select="hcmc:getFilterLabel($filterName, $filterId)"/>
-                                            <!--<xsl:value-of select="$filterName"/>-->
                                         </legend>
                                         
                                         <!--And create a ul from each of the embedded maps-->
@@ -377,7 +376,7 @@
                           
                           <!--And now create the fieldset and legend-->
                           <fieldset class="ssFieldset" title="{$filterName}" id="{$filterId}">
-                            <legend><xsl:value-of select="$filterName"/></legend>
+                            <legend><xsl:sequence select="hcmc:getFilterLabel($filterName, $filterId)"/></legend>
                             
                             <!--And create a simple text box for the feature.-->
                             <input type="text" title="{$filterName}" placeholder="{hcmc:getCaption('ssStartTyping', $captionLang)}"
@@ -416,7 +415,7 @@
                                     
                                     <fieldset class="ssFieldset" title="{$filterName}" id="{$filterId}">
                                         <!--And add the filter name as the legend-->
-                                        <legend><xsl:value-of select="$filterName"/></legend>
+                                        <legend><xsl:sequence select="hcmc:getFilterLabel($filterName, $filterId)"/></legend>
                                         <span>
                                             <label for="{$filterId}_from">From: </label>
                                             <input type="text" maxlength="10" pattern="{$dateRegex}" title="{$filterName}" id="{$filterId}_from" class="staticSearch.date staticSearch_date" placeholder="{format-date($minDate, '[Y0001]-[M01]-[D01]')}" onchange="this.reportValidity()"/>
@@ -455,7 +454,7 @@
                                     
                                     <fieldset class="ssFieldset" title="{$filterName}" id="{$filterId}">
                                         <!--And add the filter name as the legend-->
-                                        <legend><xsl:value-of select="$filterName"/></legend>
+                                        <legend><xsl:sequence select="hcmc:getFilterLabel($filterName, $filterId)"/></legend>
                                         <span>
                                             <label for="{$filterId}_from">From: </label>
                                             <input type="number" min="{$minVal}" max="{$maxVal}" placeholder="{$minVal}" step="any"

--- a/xsl/makeSearchPage.xsl
+++ b/xsl/makeSearchPage.xsl
@@ -8,7 +8,6 @@
     xmlns:map="http://www.w3.org/2005/xpath-functions/map"
     xpath-default-namespace="http://www.w3.org/1999/xhtml"
     xmlns="http://www.w3.org/1999/xhtml"
-    
     exclude-result-prefixes="#all"
     version="3.0">
     <xd:doc scope="stylesheet">
@@ -493,7 +492,8 @@
                                         <xsl:variable name="filterName" select="$jsonDoc//j:string[@key='filterName']"/>
                                         <xsl:variable name="filterId" select="$jsonDoc//j:string[@key='filterId']"/>
                                         <span>
-                                            <label for="{$filterId}"><xsl:value-of select="$filterName"/>: </label>
+                                            <xsl:sequence select="hcmc:getFilterLabel($filterName, $filterId)"/>
+                                            <!--<label for="{$filterId}"><xsl:sequence select="hcmc:getFilterLabel($filterName)"/>: </label>-->
                                             <select id="{$filterId}" title="{$filterName}" class="staticSearch.bool staticSearch_bool">
                                                 <option value="">?</option>
                                                 <!-- Check mark = true -->
@@ -606,6 +606,38 @@
                 <xsl:sequence select="()"/>
             </xsl:otherwise>
         </xsl:choose>
+    </xsl:function>
+    
+    <xd:doc>
+        <xd:desc><xd:ref name="hcmc:getFilterLabel" type="function">hcmc:getFilterLabel</xd:ref> retrieves
+        an item to be used as the label for a filter on the search page. This is either going to be the 
+        text string which is the filter name from the html:meta/@name attribute, or (if the user has 
+        overridden this in their configuration file) an HTML label element with perhaps some HTML markup
+        inside it.</xd:desc>
+        <xd:param name="filterName" as="xs:string">The string value of the @name attribute, which can 
+        be used to look up the result.</xd:param>
+        <xd:param name="filterId" as="xs:string">The id value of the filter as it will be rendered on the page.</xd:param>
+        <xd:return as="element()">An HTML label element.</xd:return>
+    </xd:doc>
+    <xsl:function name="hcmc:getFilterLabel" as="element()">
+        <xsl:param name="filterName" as="xs:string"/>
+        <xsl:param name="filterId" as="xs:string"/>    
+        <xsl:message expand-text="yes">Filter name: {$filterName}; filter id: {$filterId}; filters to check: {count($filterLabels/hcmc:filter)}</xsl:message>
+        <xsl:choose>
+            <xsl:when test="$filterLabels/hcmc:filter[@filterName=$filterName]">
+                <xsl:variable name="currLabel" select="$filterLabels/hcmc:filter[@filterName=$filterName][1]/*[1]"/>
+                <xsl:copy select="$currLabel">
+                    <xsl:copy-of select="$currLabel/@*[not(local-name() = 'for')]"/>
+                    <xsl:attribute name="for" select="$filterId"/>
+                    <xsl:copy-of select="$currLabel/node()"/>
+                    <xsl:if test="starts-with($filterId, 'ssBool')"><xsl:text>: </xsl:text></xsl:if>
+                </xsl:copy>
+            </xsl:when>
+            <xsl:otherwise>
+                <label for="{$filterId}"><xsl:sequence select="$filterName"/><xsl:text>: </xsl:text></label>
+            </xsl:otherwise>
+        </xsl:choose>
+        
     </xsl:function>
     
     <!--**************************************************************

--- a/xsl/makeSearchPage.xsl
+++ b/xsl/makeSearchPage.xsl
@@ -624,10 +624,10 @@
     <xsl:function name="hcmc:getFilterLabel" as="element()">
         <xsl:param name="filterName" as="xs:string"/>
         <xsl:param name="filterId" as="xs:string"/>    
-        <xsl:message expand-text="yes">Filter name: {$filterName}; filter id: {$filterId}; filters to check: {count($filterLabels)}</xsl:message>
+        <!--<xsl:message expand-text="yes">Filter name: {$filterName}; filter id: {$filterId}; filters to check: {count($filterLabels)}</xsl:message>-->
+        <xsl:variable name="currLabel" as="element(label)?" select="$filterLabels[@filterName=$filterName and (@lang=$pageLang or not(@lang))][1]/label[1]"/>
         <xsl:choose>
-            <xsl:when test="$filterLabels[@filterName=$filterName and (@lang=$pageLang or not(@lang))]">
-                <xsl:variable name="currLabel" select="$filterLabels[@filterName=$filterName and (@lang=$pageLang or not(@lang))][1]/*[1]"/>
+            <xsl:when test="$currLabel">
                 <xsl:copy select="$currLabel">
                     <xsl:copy-of select="$currLabel/@*[not(local-name() = 'for')]"/>
                     <xsl:attribute name="for" select="$filterId"/>

--- a/xsl/makeSearchPage.xsl
+++ b/xsl/makeSearchPage.xsl
@@ -305,7 +305,10 @@
                                     
                                     <!--And now create the fieldset and legend-->
                                     <fieldset class="ssFieldset" title="{$filterName}" id="{$filterId}">
-                                        <legend><xsl:value-of select="$filterName"/></legend>
+                                        <legend>
+                                            <xsl:sequence select="hcmc:getFilterLabel($filterName, $filterId)"/>
+                                            <!--<xsl:value-of select="$filterName"/>-->
+                                        </legend>
                                         
                                         <!--And create a ul from each of the embedded maps-->
                                         <ul class="ssDescCheckboxList">

--- a/xsl/makeSearchPage.xsl
+++ b/xsl/makeSearchPage.xsl
@@ -626,8 +626,8 @@
         <xsl:param name="filterId" as="xs:string"/>    
         <xsl:message expand-text="yes">Filter name: {$filterName}; filter id: {$filterId}; filters to check: {count($filterLabels)}</xsl:message>
         <xsl:choose>
-            <xsl:when test="$filterLabels[@filterName=$filterName]">
-                <xsl:variable name="currLabel" select="$filterLabels[@filterName=$filterName][1]/*[1]"/>
+            <xsl:when test="$filterLabels[@filterName=$filterName and (@lang=$pageLang or not(@lang))]">
+                <xsl:variable name="currLabel" select="$filterLabels[@filterName=$filterName and (@lang=$pageLang or not(@lang))][1]/*[1]"/>
                 <xsl:copy select="$currLabel">
                     <xsl:copy-of select="$currLabel/@*[not(local-name() = 'for')]"/>
                     <xsl:attribute name="for" select="$filterId"/>


### PR DESCRIPTION
This pull request forms the initial part of work on issue #268, and implements the enhancement in issue #248, allowing users to specify custom HTML label elements including other HTML markup as replacements labels for their filters. A few points to make:

1. In the section of json.xsl where the user's configuration is serialized into JSON, I haven't bothered to write serialization for the custom labels themselves; I've only recorded the fact that custom labels were specified. This is because a) there will be further features added to the hcmc:filter element which may also have to be serialized, and it'll probably make sense to do all that at the same time, but also b) I'm not really sure if we have any use for the JSON serialization of the configuration file at all, so rather than add build time and complexity I've left this for the future.
2. I've added tests for one desc filter and one boolean filter into our test suite; I think that's enough to be sure the setup is working, and adding more would require adding new filters into the test so that we have (for example) multiple date filters.
3. I'm not sure what to do about the "search only in" filter, which is a bit different from other filters in that it doesn't have a filter name arising from a meta tag. Its caption is configurable in the caption set, which is currently limited to plain text.
4. I haven't added any documentation for this feature yet, following our normal procedure which is to get a feature merged into dev before we add the documentation.