### PR TITLE
Fix overzealous removal of attributes for weight

### DIFF
--- a/configTest.xml
+++ b/configTest.xml
@@ -31,6 +31,7 @@
             match="span[@class='lineNum']"/>
         <rule weight="0"
             match="script | style"/>
+        <rule weight="10" match="span[@class='weighty']"/>
     </rules>
     
     <contexts>

--- a/test/clues.html
+++ b/test/clues.html
@@ -42,7 +42,7 @@
             <div class="text wResizable">
                 <p>This is an extract from <a href="https://journals.openedition.org/jtei/2222">Encoding Cryptic Crossword Clues with TEI</a>.</p>
                 <h1 class="texte">1. How Do Cryptic Crossword Clues Work?</h1>
-                <p class="texte" id="p1"><span class="paranumber">1</span>Whereas a “simple” crossword clue is merely a definition, a cryptic clue is a more sophisticated puzzle typically consisting of two parts: a definition and a set of codified instructions for building the solution. These components are woven into a phrase or sentence which has its own internal logic usually unconnected with the actual answer, intended to mislead the solver. This is a recent example from a <em>Guardian</em> crossword: </p>
+                <p class="texte" id="p1"><span class="paranumber">1</span>Whereas a “simple” <span class="weighty">crossword</span> clue is merely a definition, a cryptic clue is a more sophisticated puzzle typically consisting of two parts: a definition and a set of codified instructions for building the solution. These components are woven into a phrase or sentence which has its own internal logic usually unconnected with the actual answer, intended to mislead the solver. This is a recent example from a <em>Guardian</em> crossword: </p>
                 <blockquote id="q1">
                     <div class="textandnotes">
                         <ul class="sidenotes">

--- a/test/testJs/testJs.js
+++ b/test/testJs/testJs.js
@@ -374,6 +374,20 @@ tests.push({
     });
   }
 });
+//Testing an extreme weight
+tests.push({
+  setup: function () {
+    Sch.queryBox.value = 'crossword'
+  },
+  check: function (num) {
+    console.log('Search hook ' + num);
+    console.log('Testing results for heavily weighted context');
+    checkResults({
+      docsFound: 1, contextsFound: 5, scoreTotal: 16
+    });
+  }
+});
+
 
 var startTime = null;
 

--- a/xsl/tokenize.xsl
+++ b/xsl/tokenize.xsl
@@ -299,7 +299,7 @@
         <xd:desc>Template to retain all elements that have a declared language, a declared id, or a
             special data-ss- attribute since we may need those elements in other contexts.</xd:desc>
     </xd:doc>
-    <xsl:template match="*[@lang or @xml:lang or @id or @*[matches(local-name(),'^data-ss-')]][ancestor::body]" mode="clean">
+    <xsl:template match="*[@lang or @xml:lang or @id or @*[matches(local-name(),'^(data-)?ss-')]][ancestor::body]" mode="clean">
         <xsl:copy>
             <xsl:apply-templates select="@*|node()" mode="#current"/>
         </xsl:copy>
@@ -404,7 +404,7 @@
             <xsl:when test="local-name()=('id','lang')">
                 <xsl:copy-of select="."/>
             </xsl:when>
-            <xsl:when test="matches(local-name(),'^data-(staticSearch|ss)-')">
+            <xsl:when test="matches(local-name(),'^(data-)?(staticSearch|ss)-')">
                 <xsl:copy-of select="."/>
             </xsl:when>
             <xsl:otherwise/>


### PR DESCRIPTION
The switch from `@data-(staticSearch|ss)-*` to bare `@ss-` attributes was not reflected in the contextualization step, which means that weighting information was being totally ignored. This commit fixes this regression (but does not solve all of the issues with weighting and contextualization, which should be resolved in 2.0

This branch is based on `release-1.4` so should only add a single commit; since the branches have diverged so significantly, I don't think it can be plucked from here to `dev`, so that will be a separate commit/PR