### PR TITLE
Retain elements if weight is declared but is not a context

### DIFF
--- a/configTest.xml
+++ b/configTest.xml
@@ -27,6 +27,8 @@
             match="span[@class='lineNum']"/>
         <rule weight="0"
             match="script | style"/>
+        <rule weight="10" match="span[@class='weighty']"/>
+        <rule weight="5" match="td/span"/>
     </rules>
     
     <contexts>

--- a/test/clues.html
+++ b/test/clues.html
@@ -4,9 +4,9 @@
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
         <title>How do cryptic crossword clues work?</title>
-
-<meta name="Something irrelevant" content="nothing at all"/>
-
+        
+        <meta name="Something irrelevant" content="nothing at all"/>
+        
         <meta name="Document type" class="staticSearch_desc" content="Article extracts" data-ssfiltersortkey="Z"/>
         <meta name="Random nonsense" class="staticSearch_desc" content="Le Fromage Bleu"/>
         <meta name="Date range" class="staticSearch_date" content="2017/2019" />
@@ -14,17 +14,17 @@
         <meta name="Random numeric value" class="staticSearch_desc" content="2" />
         <meta name="Number of animal names" class="staticSearch_num" content="3"/>
         <meta name="docImage" class="staticSearch_docImage" content="images/crossword.png" />
-      <meta name="People involved" class="staticSearch_feat" content="Martin Holmes"/>
-      <meta name="People involved" class="staticSearch_feat" content="Nik Holmes"/>
-      <meta name="People involved" class="staticSearch_feat" content="Chris Holmes"/>
-      <meta name="People involved" class="staticSearch_feat" content="Rick Holmes"/>
-      <meta name="People involved" class="staticSearch_feat" content="Joey Takeda"/>
-      <meta name="People involved" class="staticSearch_feat" content="Captain Janeway"/>
-      <meta name="People involved" class="staticSearch_feat" content="Ada Lovelace"/>
-      <meta name="People involved" class="staticSearch_feat" content="John Stow"/>
-      <meta name="People involved" class="staticSearch_feat" content="Joan Clarke"/>
-      <meta name="People involved" class="staticSearch_feat" content="Émilie du Châtelet"/>
-      
+        <meta name="People involved" class="staticSearch_feat" content="Martin Holmes"/>
+        <meta name="People involved" class="staticSearch_feat" content="Nik Holmes"/>
+        <meta name="People involved" class="staticSearch_feat" content="Chris Holmes"/>
+        <meta name="People involved" class="staticSearch_feat" content="Rick Holmes"/>
+        <meta name="People involved" class="staticSearch_feat" content="Joey Takeda"/>
+        <meta name="People involved" class="staticSearch_feat" content="Captain Janeway"/>
+        <meta name="People involved" class="staticSearch_feat" content="Ada Lovelace"/>
+        <meta name="People involved" class="staticSearch_feat" content="John Stow"/>
+        <meta name="People involved" class="staticSearch_feat" content="Joan Clarke"/>
+        <meta name="People involved" class="staticSearch_feat" content="Émilie du Châtelet"/>
+        
         <style>
             div.text{
                 max-width: 60%;
@@ -42,21 +42,21 @@
             <div class="text wResizable">
                 <p>This is an extract from <a href="https://journals.openedition.org/jtei/2222">Encoding Cryptic Crossword Clues with TEI</a>.</p>
                 <h1 class="texte">1. How Do Cryptic Crossword Clues Work?</h1>
-                <p class="texte" id="p1"><span class="paranumber">1</span>Whereas a “simple” crossword clue is merely a definition, a cryptic clue is a more sophisticated puzzle typically consisting of two parts: a definition and a set of codified instructions for building the solution. These components are woven into a phrase or sentence which has its own internal logic usually unconnected with the actual answer, intended to mislead the solver. This is a recent example from a <em>Guardian</em> crossword: </p>
+                <p class="texte" id="p1"><span class="paranumber">1</span>Whereas a “simple” <span class="weighty">crossword</span> clue is merely a definition, a cryptic clue is a more sophisticated puzzle typically consisting of two parts: a definition and a set of codified instructions for building the solution. These components are woven into a phrase or sentence which has its own internal logic usually unconnected with the actual answer, intended to mislead the solver. This is a recent example from a <em>Guardian</em> crossword: </p>
                 <blockquote id="q1">
                     <div class="textandnotes">
                         <ul class="sidenotes">
                             <li><span class="num">2</span> “Cruciverbalists” (crossword compilers) are customarily known by pseudonyms, a tradition which goes back to the earliest days. The same compiler will often publish under distinct pseudonyms in different publications.</li>
                         </ul>
                     </div>
-                        <p class="citation">Amending pub sign, add in Cook’s vessel (7,5) <br />(Nutmeg<a class="footnotecall" id="bodyftn2" href="#ftn2">2</a> 2017)</p>
+                    <p class="citation">Amending pub sign, add in Cook’s vessel (7,5) <br />(Nutmeg<a class="footnotecall" id="bodyftn2" href="#ftn2">2</a> 2017)</p>
                 </blockquote>
                 <p class="paragraphesansretrait" id="p2">The answer is <em>PUDDING BASIN</em>, an anagram of “pub sign add in,” defined by “Cook’s vessel.” The instruction to decode an anagram is provided by the word “amending.” The complete clue suggests perhaps the addition of HMS Endeavour to a pub signboard. The words comprising the “constructor” (my term for instructions for constructing the answer) are purposely obscured by their distribution across a phrasal boundary. Here is a second example: </p>
                 <blockquote id="q2">
                     <p class="citation">Guard dog kept within sight (6) <br />(<em>Daily Telegraph</em> 2002)</p>
                 </blockquote>
                 <p class="paragraphesansretrait" id="p3">The definition here is the first word alone. The “constructor” can be explained thus: put a word for “dog” (CUR) inside a word for “insight” (SEE) to create <em>SECURE</em>, which can be glossed as “guard.” The coherence of the familiar phrase “guard dog” confounds the solver’s attempt to separate the constructor from the definition, as does the fact that the word “sight” is a noun in the context of the whole clue, but a verb when used as part of the constructor. Other types of cryptic clues exist, but this type (definition with instructions for construction) is the most common in modern cryptic crosswords and will be the focus of this article.</p>
-        </div>
+            </div>
             
         </div>
     </body>

--- a/test/tables/booze.html
+++ b/test/tables/booze.html
@@ -54,8 +54,8 @@
                     <td class="data"></td>
                 </tr>
                 <tr data-ss-value="414099">
-                    <td class="data" id="d6">Amount brought down as the transactions of <br /> Wholesale
-                        dealers (Importers)........</td>
+                    <td class="data" id="d6">Amount brought down as the transactions of <br /> <span>Wholesale
+                        dealers</span> (Importers)........</td>
                     <td class="data">$414,099</td>
                 </tr>
                 <tr data-ss-value="264915">

--- a/test/testJs/testJs.js
+++ b/test/testJs/testJs.js
@@ -374,6 +374,32 @@ tests.push({
     });
   }
 });
+//Testing an extreme weight
+tests.push({
+  setup: function () {
+    Sch.queryBox.value = 'crossword'
+  },
+  check: function (num) {
+    console.log('Search hook ' + num);
+    console.log('Testing results for heavily weighted context');
+    checkResults({
+      docsFound: 1, contextsFound: 5, scoreTotal: 16
+    });
+  }
+});
+//Testing a weight inside a table cell context.
+tests.push({
+  setup: function(){
+    Sch.queryBox.value = 'wholesale'
+  },
+  check: function(num){
+    console.log('search hook ' + num);
+    console.log('Testing results for weighted search in td context');
+    checkResults({
+      docsFound: 1, contextsFound: 2, scoreTotal: 6
+    })
+  }
+})
 
 var startTime = null;
 

--- a/xsl/create_config_xsl.xsl
+++ b/xsl/create_config_xsl.xsl
@@ -454,10 +454,20 @@
                             </xso:if>
                             <xso:call-template name="hcmc:copy"/>
                         </xso:when>
-                        <xso:when test="not(empty($weights)) and $weights[last()] = 0">
-                            <xso:if test="$verbose">
-                                <xso:message>config#decorate: Removing <xso:value-of select="local-name()"/> (weight=0)</xso:message>
-                            </xso:if>
+                        <!--If there is weighting info, then either...-->
+                        <xso:when test="not(empty($weights))">
+                            <xso:choose>
+                                <!--It should be removed (since it's a weight=0)-->
+                                <xso:when test="$weights[last()] = 0">
+                                    <xso:if test="$verbose">
+                                        <xso:message>config#decorate: Removing <xso:value-of select="local-name()"/> (weight=0)</xso:message>
+                                    </xso:if>
+                                </xso:when>
+                                <!--Or it must be retained-->
+                                <xso:otherwise>
+                                    <xso:call-template name="hcmc:copy"/>
+                                </xso:otherwise>
+                            </xso:choose>
                         </xso:when>
                         <xso:when test="empty($contexts) or ($contexts[last()] = false())">
                             <xso:apply-templates select="node()" mode="#current"/>


### PR DESCRIPTION
Previously, if an element wasn't a context (e.g. a span without explicitly being set as a context), only its children were processed, which mean that spans with a weight attached were being dropped. This makes the conditional a bit more aware of the combinations that should make an element be retained. 