### PR TITLE
Iss297 tfidf

### DIFF
--- a/xsl/json.xsl
+++ b/xsl/json.xsl
@@ -697,7 +697,6 @@
     </xd:doc>
     <xsl:function name="hcmc:getTotalTermsInDoc" as="xs:integer" new-each-time="no">
         <xsl:param name="docUri" as="xs:string"/>
-        <xsl:message select="$docUri"/>
         <xsl:variable name="thisDoc" select="$tokenizedDocs[base-uri(.) = $docUri]" as="document-node()"/>
         <xsl:variable name="thisDocSpans" select="$thisDoc//span[@ss-stem]" as="element(span)*"/>
         <!--We tokenize these since there can be multiple stems for a given span-->

--- a/xsl/json.xsl
+++ b/xsl/json.xsl
@@ -697,7 +697,8 @@
     </xd:doc>
     <xsl:function name="hcmc:getTotalTermsInDoc" as="xs:integer" new-each-time="no">
         <xsl:param name="docUri" as="xs:string"/>
-        <xsl:variable name="thisDoc" select="$tokenizedDocs[document-uri(.) = $docUri]" as="document-node()"/>
+        <xsl:message select="$docUri"/>
+        <xsl:variable name="thisDoc" select="$tokenizedDocs[base-uri(.) = $docUri]" as="document-node()"/>
         <xsl:variable name="thisDocSpans" select="$thisDoc//span[@ss-stem]" as="element(span)*"/>
         <!--We tokenize these since there can be multiple stems for a given span-->
         <xsl:variable name="thisDocStems" select="for $span in $thisDocSpans return tokenize($span/@ss-stem,'\s+')" as="xs:string+"/>

--- a/xsl/makeSearchPage.xsl
+++ b/xsl/makeSearchPage.xsl
@@ -233,6 +233,7 @@
                 data-allowwildcards="{if ($wildcardSearch) then 'yes' else 'no'}"
                 data-minwordlength="{if ($minWordLength) then $minWordLength else '3'}"
                 data-maxkwicstoshow="{if ($maxKwicsToShow) then $maxKwicsToShow else 10}"
+                data-scoringalgorithm="{if ($scoringAlgorithm) then $scoringAlgorithm else 'raw'}"
                 data-resultsperpage="{$resultsPerPage}"
                 onsubmit="return false;"
                 data-versionstring="{$versionString}"


### PR DESCRIPTION
This does two (minor) things:

1. Fixes the hcmc:getTotalTermsInDoc function (which just failed entirely due to document-uri() no longer working)
2. Add `@data-scoringalgorithm` to the search HTML (since it may be useful to have as information for the scoring)