### PR TITLE
Iss 293 ampersands

### DIFF
--- a/js/StaticSearch.js
+++ b/js/StaticSearch.js
@@ -819,6 +819,8 @@ class StaticSearch{
       //Then remove any leading or trailing apostrophes
       strSearch = strSearch.replace(/(^'|'$)/g,'');
 
+      //Now escape ampersands.
+      strSearch = strSearch.replace(/&/g, '&amp;');
 
       //If we're not supporting phrasal searches, get rid of double quotes.
       if (!this.allowPhrasal){
@@ -873,8 +875,9 @@ class StaticSearch{
       this.addSearchItem(strSoFar, inPhrase);
      
       // Now clear the queryBox and replace its contents
-      // By joining the normalized query
-      this.queryBox.value = this.normalizedQuery.join(" ");
+      // by joining the normalized query, and putting 
+      // any ampersands back where they were.
+      this.queryBox.value = this.normalizedQuery.join(" ").replace(/&amp;/, '&');
       
 
       //We always want to handle the terms in order of

--- a/test/badthings.html
+++ b/test/badthings.html
@@ -52,6 +52,10 @@
             
             <p>One type of out-stretched: out-stretcht</p>
             <p>Another type of out-stretched: out-ſtretcht</p>
+            
+            <p>We need to check the correct handling of ampersands in genuine contexts, such as the name Marks &amp; Spencer.</p>
+            
+            <p>But the same name might be written Marks &#x0026; Spencer, or Marks &#38; Spencer.</p>
           
           <p>Now let's try some stuff that ought to be carefully sanitized 
             during indexing. This word should not appear in bold in the results: &lt;b&gt;bold&lt;/b&gt;. 

--- a/test/testJs/testJs.js
+++ b/test/testJs/testJs.js
@@ -218,6 +218,20 @@ tests.push({
   }
 });
 
+//Phrasal search with ampersand.
+tests.push({
+  setup: function () {
+    Sch.queryBox.value = '"Marks & Spencer"'
+  },
+  check: function (num) {
+    console.log('Search hook ' + num);
+    console.log('Testing results for the phrase "Marks & Spencer".');
+    checkResults({
+      docsFound: 1, contextsFound: 3, scoreTotal: 3
+    });
+  }
+});
+
 //Two MUST_CONTAINs with boolean flag.
 tests.push({
   setup: function () {


### PR DESCRIPTION
Fix for the issue of searching for phrases containing ampersands not working, along with a test for it. When merged, I'll backport into the 1.4 release.