### PR TITLE
Fix for issue #319

### DIFF
--- a/test/badthings.html
+++ b/test/badthings.html
@@ -56,6 +56,8 @@
             <p>We need to check the correct handling of ampersands in genuine contexts, such as the name Marks &amp; Spencer.</p>
             
             <p>But the same name might be written Marks &#x0026; Spencer, or Marks &#38; Spencer.</p>
+            
+            <p>Now we have a little bit of nxaʔamxčín for testing: ʔaʔíxa kn‿kaš čnúx̌ʷtəxʷ should be tokenized into three words, and kn‿kaš should be findable.</p>
           
           <p>Now let's try some stuff that ought to be carefully sanitized 
             during indexing. This word should not appear in bold in the results: &lt;b&gt;bold&lt;/b&gt;. 

--- a/test/testJs/testJs.js
+++ b/test/testJs/testJs.js
@@ -430,6 +430,20 @@ tests.push({
     })
   }
 })
+//Testing tokenization with a word containing an undertie (connector punctuation).
+tests.push({
+  setup: function(){
+    Sch.queryBox.value = 'kn‿kaš'
+  },
+  check: function(num){
+    console.log('search hook ' + num);
+    console.log('Testing results for a word containing connector punctuation');
+    checkResults({
+      docsFound: 1, contextsFound: 2, scoreTotal: 2
+    })
+  }
+})
+
 
 var startTime = null;
 

--- a/xsl/tokenize.xsl
+++ b/xsl/tokenize.xsl
@@ -123,7 +123,7 @@
         although it should be covered by \p{L}, because of an apparent bug in
         Java or Saxon regex processing; see GH issue #200.</xd:desc>
     </xd:doc>
-  <xsl:variable name="alphanumeric">[&#xA78F;\p{L}\p{M}<xsl:value-of select="string-join($allApos,'')"/>]+</xsl:variable>
+  <xsl:variable name="alphanumeric">[&#xA78F;\p{L}\p{M}\p{Pc}<xsl:value-of select="string-join($allApos,'')"/>]+</xsl:variable>
     
     <xd:doc>
         <xd:desc>Regex to match hyphenated words</xd:desc>


### PR DESCRIPTION
Added connector punctuation class to regex, and new test using phrase from nxaʔamxčín. All tests pass.