### PR TITLE
Issue 363 conversion bug

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -276,6 +276,17 @@ Would you like to overwrite the existing file or &#x0a;
 create a new file? (o=overwrite, n=new)"
            validargs="o,n"
            defaultvalue="n"/>
+    
+    <!-- If overwriting, we'll make sure a backup is created first
+         in case something goes wrong. -->
+    <if>
+      <equals arg1="${outputStrategy}" arg2="o"/>
+      <then>
+        <copy file="${ssBaseDir.converted}/${ssConfig}" tofile="${ssBaseDir.converted}/${ssConfig}.BAK"/>
+        <echo message="A backup of your config file has been created: ${ssBaseDir.converted}/${ssConfig}.BAK"/>
+      </then>
+    </if>
+    
     <!--<echo message="${outputStrategy}"/>-->
     <java classpath="${ssSaxon}" classname="net.sf.saxon.Transform" failonerror="true" fork="true">
       <arg value="-xsl:${ssBaseDir.converted}/xsl/convert_v1_to_v2.xsl"/>

--- a/xsl/convert_v1_to_v2.xsl
+++ b/xsl/convert_v1_to_v2.xsl
@@ -245,12 +245,12 @@
         <xd:desc>Function to create boolean string values from unreliable or absent input.</xd:desc>
         <xd:param name="input" as="item()?">May be an element, attribute, or text node
             which contains the original value if it exists.</xd:param>
-        <xd:param name="default" as="xs:string">The default value to use if the input does 
+        <xd:param name="default" as="xs:boolean">The default value to use if the input does 
             not provide anything usable.</xd:param>
     </xd:doc>
     <xsl:function name="hcmc:getStrBoolean" as="xs:string">
         <xsl:param name="input" as="item()?"/>
-        <xsl:param name="default" as="xs:string"/>
+        <xsl:param name="default" as="xs:boolean"/>
         <xsl:choose>
             <xsl:when test="$input and matches($input, $reBooleanTrue, 'i')">
                 <xsl:sequence select="'true'"/>
@@ -258,8 +258,11 @@
             <xsl:when test="$input and matches($input, $reBooleanFalse, 'i')">
                 <xsl:sequence select="'false'"/>
             </xsl:when>
+            <xsl:when test="$default">
+                <xsl:sequence select="'true'"/>
+            </xsl:when>
             <xsl:otherwise>
-                <xsl:sequence select="$default"/>
+                <xsl:sequence select="'false'"/>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:function>
@@ -268,14 +271,15 @@
         <xd:desc>Function to create string values from unreliable or absent input.</xd:desc>
         <xd:param name="input" as="item()?">May be an element, attribute, or text node
             which contains the original value if it exists.</xd:param>
-        <xd:param name="default" as="xs:string">The default value to use if the input does 
+        <xd:param name="default" as="xs:string?">The default value to use if the input does 
         not provide anything usable.</xd:param>
     </xd:doc>
     <xsl:function name="hcmc:getString" as="xs:string">
         <xsl:param name="input" as="item()?"/>
-        <xsl:param name="default" as="xs:string"/>
+        <xsl:param name="default" as="xs:string?"/>
+        <xsl:message select="xs:string($input)"/>
         <xsl:choose>
-            <xsl:when test="$input and string-length($input) gt 0">
+            <xsl:when test="xs:string($input) and string-length($input) gt 0">
                 <xsl:sequence select="xs:string($input)"/>
             </xsl:when>
             <xsl:otherwise>


### PR DESCRIPTION
Somehow the original v1-v2 conversion code was broken, probably by changes to xsl/process_schema_for_config.xsl that resulted in default values not being what they were expected to be by the functions in the conversion code. I think this catches all problem cases.