### PR TITLE
Fix for issue #386: truncate over-long version string.

### DIFF
--- a/xsl/constants.xsl
+++ b/xsl/constants.xsl
@@ -27,4 +27,9 @@
     <xsl:param name="KEY_CONTEXT_IDS" as="xs:string" static="yes" select="'contextIds'"/>
     <xsl:param name="KEY_EXCLUDES" as="xs:string" static="yes" select="'excludes'"/>
     
+    <!-- We set the maximum length of a version string to 32 characters because 
+         version strings are used in constructing filenames, and filenames should
+         not be excessively long. -->
+    <xsl:param name="MAXLEN_VERSION_STRING" as="xs:integer" static="yes" select="32"/>
+    
 </xsl:stylesheet>

--- a/xsl/create_config_xsl.xsl
+++ b/xsl/create_config_xsl.xsl
@@ -138,7 +138,13 @@
                         select="unparsed-text(resolve-uri($mergedParams?version.file, $configUri)) =>
                         normalize-space() =>
                         replace('\s+','_')"/>
-                    <xsl:sequence select="if (starts-with($v,'_')) then $v else ('_' || $v)"/>
+                    <!-- Issue a warning if the version string is too long. -->
+                    <xsl:if test="string-length($v) gt $MAXLEN_VERSION_STRING">
+                        <xsl:message>BE WARNED: The version string is too long, and will 
+                        be truncated to <xsl:value-of select="$MAXLEN_VERSION_STRING"/> 
+                        characters.</xsl:message>
+                    </xsl:if>
+                    <xsl:sequence select="if (starts-with($v,'_')) then substring($v, 1, $MAXLEN_VERSION_STRING) else ('_' || substring($v, 1, $MAXLEN_VERSION_STRING))"/>
                     <xsl:catch>
                         <xsl:message>WARNING: No version file specified.</xsl:message>
                         <xsl:sequence select="'_' || hcmc:generateRandomHash()"/>


### PR DESCRIPTION
I did test this by tweaking the test build to use a fixed file with an over-long string in it, and it works fine.
